### PR TITLE
fix(ci): mirror sites registry + bump deprecated actions

### DIFF
--- a/.github/workflows/blog-image-optimization.yml
+++ b/.github/workflows/blog-image-optimization.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -18,9 +18,9 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/offers-auto-extend.yml
+++ b/.github/workflows/offers-auto-extend.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/offers-edit-item.yml
+++ b/.github/workflows/offers-edit-item.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/offers-edit-regions.yml
+++ b/.github/workflows/offers-edit-regions.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/update-sitemap-llms.yml
+++ b/.github/workflows/update-sitemap-llms.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6

--- a/.github/workflows/weglot-daily-report.yml
+++ b/.github/workflows/weglot-daily-report.yml
@@ -17,7 +17,7 @@ jobs:
   daily-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Check for pending CSV
         id: check

--- a/.github/workflows/weglot-sync.yml
+++ b/.github/workflows/weglot-sync.yml
@@ -17,7 +17,7 @@ jobs:
   sync-exclusions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/sites/cel/site.json
+++ b/sites/cel/site.json
@@ -1,0 +1,9 @@
+{
+  "_note": "Minimal mirror of the monorepo cel site config, scoped to fields read by the blog-image optimizer + asset_upload helpers (webflow_site_id, _site_path resolution). Update in lockstep with cagdasunal/webflow:sites/cel/site.json if the optimizer starts consuming additional fields.",
+  "nickname": "cel",
+  "name": "Canadian English Language College",
+  "platform": "webflow",
+  "webflow_site_id": "667453c576e8d35c454cc9ae",
+  "staging_url": "https://englishcollege.webflow.io",
+  "language": "en"
+}

--- a/sites/registry.json
+++ b/sites/registry.json
@@ -1,0 +1,14 @@
+{
+  "_note": "Minimal mirror of the monorepo registry, scoped to CEL only. Loaded by scripts/optimize_blog_richtext_images.py (via scripts/asset_upload.py load_site_config). Update in lockstep with the canonical version in cagdasunal/webflow:sites/registry.json when fields the optimizer reads change.",
+  "sites": {
+    "cel": {
+      "name": "Canadian English Language College",
+      "platform": "webflow",
+      "staging_url": "https://englishcollege.webflow.io",
+      "production_url": null,
+      "language": "en",
+      "path": "sites/cel"
+    }
+  },
+  "default_site": "cel"
+}


### PR DESCRIPTION
## Summary

Two CI failures, fixed together because they touch the same workflow set:

1. **Nightly Blog Image Optimization** was failing with `Error: No registry at /home/runner/work/CEL/CEL/sites/registry.json` ([run 25627851906](https://github.com/cagdasunal/CEL/actions/runs/25627851906), [run 25673922678](https://github.com/cagdasunal/CEL/actions/runs/25673922678)). The optimizer imports \`load_site_config\` which reads \`sites/registry.json\` + \`sites/cel/site.json\` — neither existed in this repo. Mirror them minimally with a \`_note\` field warning future contributors to keep them in lockstep with the monorepo canonical (\`cagdasunal/webflow:sites/...\`).
2. **\`Node.js 20 actions are deprecated\`** annotations on every run. GitHub is forcing Node 24 on 2026-06-02. Bump \`actions/checkout@v4|v5 → v6\` and \`actions/setup-python@v5 → v6\` across all 8 workflows.

## Files
- ➕ \`sites/registry.json\` — single-entry \`cel\` mirror
- ➕ \`sites/cel/site.json\` — \`webflow_site_id\` + nickname/path
- 🔧 8 workflows under \`.github/workflows/\` bumped to v6 actions

## Test plan
- [x] Local: \`python3 scripts/optimize_blog_richtext_images.py --site cel --dry-run\` now passes the config gate (previously failed with `Error: No registry`)
- [ ] **Post-merge**: re-run \`Blog Image Optimization\` workflow from the Actions tab and confirm it gets past the registry check (it will still need \`WEBFLOW_API_TOKEN\` to do anything real, but the registry error is gone)
- [ ] **Post-merge**: next nightly run (Cron 11:00 UTC) should complete without a registry error

🤖 Generated with [Claude Code](https://claude.com/claude-code)