### PR TITLE
fix: resolve 7 /review nits on the core refactor (review 001)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 tools/
 ├── core/          # SHARED SERVICES (leaf — import these; never imports a consumer back)
 │   ├── gemini/    # Gemini 3.1 Pro client (Plan A): BatchRequest, submit_batch, generate_sync, wait_for_batch, cost/cache
-│   ├── webflow/   # Webflow Data API (Plan B): http (auth/retry/pagination) + cms (generic field PATCH, create/bulk, dry-run)
+│   ├── webflow/   # Webflow Data API (Plan B): http (auth/retry/backoff) + cms (generic field PATCH + paginated reads + ensure-field, dry-run)
 │   ├── web/       # page_fetcher (Plan B2): live-page fetch -> PageContent
 │   ├── content/   # structure (Plan B2): Markdown <-> Webflow RichText HTML
 │   └── seo/       # llms_parser (Plan B2): llms.txt -> LlmsIndex internal-link graph

--- a/docs/reviews/001-review-fix-2026-05-25.md
+++ b/docs/reviews/001-review-fix-2026-05-25.md
@@ -1,0 +1,35 @@
+# Review Fix — 2026-05-25
+
+> Source: /review run 2026-05-25 on PR #42 (refactor(core): modular tools/core extraction — merged to main)
+> Scope: all findings ("apply all recommendations, don't leave anything behind")
+> Baseline commit: 8af7caa
+> Tracker: docs/reviews/001-review-fix-2026-05-25.md
+
+## Status
+
+| Category | Total | Done | Remaining | % |
+|----------|-------|------|-----------|---|
+| Critical | 0 | 0 | 0 | — |
+| High     | 0 | 0 | 0 | — |
+| Medium   | 0 | 0 | 0 | — |
+| Low      | 5 | 0 | 5 | 0% |
+| Info     | 2 | 0 | 2 | 0% |
+| **Total**| 7 | 0 | 7 | 0% |
+
+Last updated: 2026-05-25 · Second pass: pending
+
+## Low
+
+- [ ] #1 [docs] `tools/core/README.md` over-claims `core.webflow.http`: remove `paginate` + `NetworkError` (neither exists — pagination is in `cms.list_items`; errors raise `WebflowApiError`). — `tools/core/README.md`
+- [ ] #2 [docs] `docs/ARCHITECTURE.md` over-claims webflow: drop "pagination" (http) + "create/bulk" (cms) — neither exists. — `docs/ARCHITECTURE.md`
+- [ ] #3 [code] `copywriter.prompt_builder.build_system_prompt` has an unused `content_type` param: drop it + update the `engine.py` caller (content_type already reaches the model via the user message). — `tools/copywriter/prompt_builder.py:16`, `tools/copywriter/engine.py:45`
+- [ ] #5 [maint] `summary/config.py` defines Gemini knobs locally then shadows them via the trailing `core.gemini.config` import: delete the dead locals (canonical commented versions live in `core/gemini/config.py`). — `tools/summary/config.py`
+- [ ] #7 [security] `copywriter/cli.py::_resolve_before` fetches `target.url` with no allowlist: restrict to `https://*.englishcollege.com` + add a regression test. — `tools/copywriter/cli.py`, `tools/copywriter/tests/test_cli.py` (new)
+
+## Info
+
+- [ ] #4 [cosmetic] `core/webflow/cms.py` User-Agent `cel-summary-script/1.0` → `cel-webflow-client/1.0` (shared client). Scoped to cms.py per the finding; `page_fetcher`/`llms_parser` live-fetch UAs left intentionally (unflagged + behavior-change risk against public servers). — `tools/core/webflow/cms.py:75`
+- [ ] #6 [process] PR #42 title stale ("Plan 0 + B2") — update via `gh pr edit 42` to reflect all 6 plans. — (scope: GitHub)
+
+## Second Pass
+_To be filled after Phase 4._

--- a/docs/reviews/001-review-fix-2026-05-25.md
+++ b/docs/reviews/001-review-fix-2026-05-25.md
@@ -12,24 +12,35 @@
 | Critical | 0 | 0 | 0 | — |
 | High     | 0 | 0 | 0 | — |
 | Medium   | 0 | 0 | 0 | — |
-| Low      | 5 | 0 | 5 | 0% |
-| Info     | 2 | 0 | 2 | 0% |
-| **Total**| 7 | 0 | 7 | 0% |
+| Low      | 5 | 5 | 0 | 100% |
+| Info     | 2 | 2 | 0 | 100% |
+| **Total**| 7 | 7 | 0 | 100% |
 
-Last updated: 2026-05-25 · Second pass: pending
+Last updated: 2026-05-25 · Second pass: clean (mechanical sweep — no new findings)
 
 ## Low
 
-- [ ] #1 [docs] `tools/core/README.md` over-claims `core.webflow.http`: remove `paginate` + `NetworkError` (neither exists — pagination is in `cms.list_items`; errors raise `WebflowApiError`). — `tools/core/README.md`
-- [ ] #2 [docs] `docs/ARCHITECTURE.md` over-claims webflow: drop "pagination" (http) + "create/bulk" (cms) — neither exists. — `docs/ARCHITECTURE.md`
-- [ ] #3 [code] `copywriter.prompt_builder.build_system_prompt` has an unused `content_type` param: drop it + update the `engine.py` caller (content_type already reaches the model via the user message). — `tools/copywriter/prompt_builder.py:16`, `tools/copywriter/engine.py:45`
-- [ ] #5 [maint] `summary/config.py` defines Gemini knobs locally then shadows them via the trailing `core.gemini.config` import: delete the dead locals (canonical commented versions live in `core/gemini/config.py`). — `tools/summary/config.py`
-- [ ] #7 [security] `copywriter/cli.py::_resolve_before` fetches `target.url` with no allowlist: restrict to `https://*.englishcollege.com` + add a regression test. — `tools/copywriter/cli.py`, `tools/copywriter/tests/test_cli.py` (new)
+- [x] #1 [docs] `tools/core/README.md` over-claims `core.webflow.http`: removed `paginate` + `NetworkError` (neither exists — pagination is in `cms.list_items`; errors raise `WebflowApiError`). — `tools/core/README.md`
+- [x] #2 [docs] `docs/ARCHITECTURE.md` over-claims webflow: dropped "pagination" (http) + "create/bulk" (cms). — `docs/ARCHITECTURE.md`
+- [x] #3 [code] `copywriter.prompt_builder.build_system_prompt` unused `content_type` param: dropped it + updated the `engine.py` caller (content_type reaches the model via the user message). — `tools/copywriter/prompt_builder.py:16`, `tools/copywriter/engine.py:45`
+- [x] #5 [maint] `summary/config.py` dead local Gemini knobs shadowed by the trailing `core.gemini.config` import: deleted (−89 lines; canonical commented copies live in `core/gemini/config.py`; behavioral no-op). — `tools/summary/config.py`
+- [x] #7 [security] `copywriter/cli.py::_resolve_before` fetched `target.url` with no allowlist: added `https://*.englishcollege.com` guard (`_is_allowlisted_url`) + 4 regression tests. — `tools/copywriter/cli.py`, `tools/copywriter/tests/test_cli.py`
 
 ## Info
 
-- [ ] #4 [cosmetic] `core/webflow/cms.py` User-Agent `cel-summary-script/1.0` → `cel-webflow-client/1.0` (shared client). Scoped to cms.py per the finding; `page_fetcher`/`llms_parser` live-fetch UAs left intentionally (unflagged + behavior-change risk against public servers). — `tools/core/webflow/cms.py:75`
-- [ ] #6 [process] PR #42 title stale ("Plan 0 + B2") — update via `gh pr edit 42` to reflect all 6 plans. — (scope: GitHub)
+- [x] #4 [cosmetic] `core/webflow/cms.py` User-Agent `cel-summary-script/1.0` → `cel-webflow-client/1.0`. Scoped to cms.py per the finding; `page_fetcher`/`llms_parser` live-fetch UAs left intentionally (unflagged + behavior-change risk against public servers). — `tools/core/webflow/cms.py:75`
+- [x] #6 [process] PR #42 title updated via `gh pr edit 42` to "refactor(core): modular tools/core extraction + copywriter + stress harness (Plans 0/B2/A/B/C/D)". — (GitHub)
 
 ## Second Pass
-_To be filled after Phase 4._
+
+Phase 4a mechanical sweep on all changed files: no dead imports, no debug markers
+(`TODO`/`FIXME`/`print(DEBUG`/`console.log`), no module-level `sys.exit`. No new findings.
+
+## Summary
+
+- Findings: 7 total → 7 fixed, 0 deferred, 0 regressions.
+- Commits: 2 on branch `fix/review-nits-2026-05-25` (low + info) + the `gh` PR-title edit (#6).
+- Gate: full suite **481 tests / 479 passed / 2 known-failing** (`tools/test_update_log.py`
+  sitemap-host asserts — pre-existing, OUT OF SCOPE) / 0 errors; `lint-imports` 1 kept / 0 broken;
+  `run_stress.sh` exit 0. (Count rose 477 → 481 from the 4 new `test_cli.py` tests.)
+- Second pass: clean.

--- a/tools/copywriter/cli.py
+++ b/tools/copywriter/cli.py
@@ -17,11 +17,20 @@ import dataclasses
 import json
 import sys
 import time
+import urllib.parse
 from pathlib import Path
 
 from tools.copywriter import config, webflow_writer
 from tools.copywriter.brief import CopyRequest, CopyResult, load_brief
 from tools.copywriter.engine import improve_copy
+
+
+def _is_allowlisted_url(url: str) -> bool:
+    """Only fetch over https from englishcollege.com (defensive — the target URL is
+    operator-supplied via the brief; restrict the fetch surface to the known domain)."""
+    p = urllib.parse.urlparse(url)
+    host = (p.hostname or "").lower()
+    return p.scheme == "https" and (host == "englishcollege.com" or host.endswith(".englishcollege.com"))
 
 
 def _resolve_before(req: CopyRequest) -> CopyRequest:
@@ -30,11 +39,16 @@ def _resolve_before(req: CopyRequest) -> CopyRequest:
         return req
     tgt = req.target or {}
     if tgt.get("kind") == "static_page" and tgt.get("url"):
+        url = tgt["url"]
+        if not _is_allowlisted_url(url):
+            print(f"[copywriter] refusing to fetch non-allowlisted URL "
+                  f"(https + *.englishcollege.com only): {url}", file=sys.stderr)
+            return req
         from tools.core.web.page_fetcher import fetch_page
         try:
-            return dataclasses.replace(req, existing_copy=fetch_page(tgt["url"]).body_text_excerpt)
+            return dataclasses.replace(req, existing_copy=fetch_page(url).body_text_excerpt)
         except Exception as e:  # noqa: BLE001 — fetch failure is non-fatal; proceed with empty
-            print(f"[copywriter] could not fetch {tgt['url']}: {e}", file=sys.stderr)
+            print(f"[copywriter] could not fetch {url}: {e}", file=sys.stderr)
     return req
 
 

--- a/tools/copywriter/engine.py
+++ b/tools/copywriter/engine.py
@@ -42,7 +42,7 @@ def improve_copy(
 ) -> CopyResult:
     """Improve `req`'s copy in `req.locale` (locale-native; never translates)."""
     before = req.existing_copy or ""
-    system_blocks = build_system_prompt(req.locale, req.content_type)
+    system_blocks = build_system_prompt(req.locale)
     user_message = build_user_message(req, before, link_candidates)
 
     if dry_run:

--- a/tools/copywriter/prompt_builder.py
+++ b/tools/copywriter/prompt_builder.py
@@ -13,8 +13,12 @@ from tools.copywriter import config
 from tools.copywriter.brief import CopyRequest
 
 
-def build_system_prompt(locale: str, content_type: str = "marketing") -> list[dict]:
-    """Return system-prompt blocks: [copywriter common.md, locale layer]."""
+def build_system_prompt(locale: str) -> list[dict]:
+    """Return system-prompt blocks: [copywriter common.md, locale layer].
+
+    (Content type is conveyed to the model via build_user_message, not the system
+    prompt — there is no per-content-type system layer, so it isn't a parameter here.)
+    """
     common = (config.PROMPTS_DIR / "common.md").read_text(encoding="utf-8")
     blocks = [{"type": "text", "text": common}]
     locale_path = Path(config.LOCALE_LAYERS_DIR) / f"{locale}.md"

--- a/tools/copywriter/tests/test_cli.py
+++ b/tools/copywriter/tests/test_cli.py
@@ -1,0 +1,52 @@
+"""copywriter CLI — the fetch allowlist (defensive guard on _resolve_before).
+
+The static-page target URL is operator-supplied via the brief; _resolve_before must
+only fetch over https from englishcollege.com, and must NOT call out for anything else.
+"""
+import types
+
+from tools.copywriter.brief import CopyRequest
+from tools.copywriter.cli import _is_allowlisted_url, _resolve_before
+
+
+def test_is_allowlisted_url_accepts_https_englishcollege():
+    assert _is_allowlisted_url("https://www.englishcollege.com/courses")
+    assert _is_allowlisted_url("https://cel.englishcollege.com/llms.txt")
+    assert _is_allowlisted_url("https://englishcollege.com/")
+
+
+def test_is_allowlisted_url_rejects_other():
+    assert not _is_allowlisted_url("http://www.englishcollege.com/x")        # not https
+    assert not _is_allowlisted_url("https://evil.example.com/x")             # wrong host
+    assert not _is_allowlisted_url("https://englishcollege.com.evil.com/x")  # suffix trick
+    assert not _is_allowlisted_url("https://evil-englishcollege.com/x")      # prefix trick
+
+
+def test_resolve_before_refuses_non_allowlisted_url(monkeypatch):
+    import tools.core.web.page_fetcher as pf
+    calls = {"n": 0}
+
+    def _spy(*a, **k):
+        calls["n"] += 1
+        return types.SimpleNamespace(body_text_excerpt="SHOULD NOT BE USED")
+
+    monkeypatch.setattr(pf, "fetch_page", _spy)
+    req = CopyRequest(brief="x", target={"kind": "static_page", "url": "http://evil.example.com/x"})
+    out = _resolve_before(req)
+    assert calls["n"] == 0            # fetch_page never called for a non-allowlisted URL
+    assert out.existing_copy == ""    # proceeds with empty copy (non-fatal)
+
+
+def test_resolve_before_fetches_allowlisted_url(monkeypatch):
+    import tools.core.web.page_fetcher as pf
+    calls = {"n": 0}
+
+    def _spy(url, *a, **k):
+        calls["n"] += 1
+        return types.SimpleNamespace(body_text_excerpt="Fetched body.")
+
+    monkeypatch.setattr(pf, "fetch_page", _spy)
+    req = CopyRequest(brief="x", target={"kind": "static_page", "url": "https://www.englishcollege.com/courses"})
+    out = _resolve_before(req)
+    assert calls["n"] == 1
+    assert out.existing_copy == "Fetched body."

--- a/tools/core/README.md
+++ b/tools/core/README.md
@@ -10,7 +10,7 @@ back-import fails CI, not a code review. See [`docs/ARCHITECTURE.md`](../../docs
 | Package | Module(s) | Public surface |
 |---|---|---|
 | `core.gemini` | `client`, `config` | Gemini 3.1 Pro Batch + sync client: `BatchRequest`, `submit_batch`, `generate_sync`, `wait_for_batch`, `dry_run_submit`, `cancel_batch`, `estimate_batch_cost_usd`, `plan_caches`; knobs in `config` (`MODEL_ID`, cache/token/cost constants, `DRYRUN_DIR`, `LAST_BATCH_FILE`). |
-| `core.webflow` | `http`, `cms` | Webflow Data API: `http` = `resolve_token` + `request` (429/5xx + timeout backoff) + `paginate` + `WebflowApiError`/`NetworkError`; `cms.CmsClient` = generic staged `patch_fields`, `list_items`, `ensure_field`, dry-run default; `WriteResult`/`CmsItem`/`CollectionField`. |
+| `core.webflow` | `http`, `cms` | Webflow Data API: `http` = `resolve_token` + `request` (429/5xx + timeout backoff) + `WebflowApiError`; `cms.CmsClient` = generic staged `patch_fields`, paginated `list_items`, `ensure_field`, dry-run default; `WriteResult`/`CmsItem`/`CollectionField`. |
 | `core.web` | `page_fetcher` | `fetch_page(url) -> PageContent` (stdlib live-page fetch + extract). |
 | `core.content` | `structure` | Markdown ⇄ Webflow RichText HTML (`summary_markdown_to_html`, `summary_html_to_markdown`, `parse_four_part`, …). |
 | `core.seo` | `llms_parser` | `llms.txt` → `LlmsIndex` internal-link graph (`parse_llms_txt`, `find_equivalent`, `LlmsIndex.find_equivalent_or_fallback`). |

--- a/tools/core/webflow/cms.py
+++ b/tools/core/webflow/cms.py
@@ -72,7 +72,7 @@ class CmsClient:
         h = {
             "Authorization": f"Bearer {self._get_token()}",
             "Accept": "application/json",
-            "User-Agent": "cel-summary-script/1.0",
+            "User-Agent": "cel-webflow-client/1.0",
         }
         if content_type_json:
             h["Content-Type"] = "application/json"

--- a/tools/summary/config.py
+++ b/tools/summary/config.py
@@ -1,37 +1,13 @@
 """Config — locale codes, collection IDs, model, exclusions, paths.
 
-Single source of truth for IDs and rules. No business logic — pure constants.
-Update MODEL_ID when a more capable Gemini production model ships.
+Single source of truth for summary IDs and rules. No business logic — pure constants.
+The shared Gemini knobs (MODEL_ID, model tiering, caching, token estimates, the dry-run
++ last-batch paths) live in tools.core.gemini.config and are re-exported at the bottom of
+this module; only summary-specific constants are defined here.
 """
 from __future__ import annotations
 
 from pathlib import Path
-
-# Google Gemini 3.1 Pro Preview — top-tier production model on Artificial
-# Analysis Intelligence Index (tied with Opus 4.7 at 57). Migrated from
-# claude-opus-4-7 in tracker-091 (2026-05-19 evening).
-# Pricing reference (verified 2026-05-21 — tracker-097): interactive
-# $2.00 in / $12.00 out per 1M (≤200k ctx); Batch $1.00 / $6.00; cached read $0.20.
-# https://ai.google.dev/gemini-api/docs/pricing
-MODEL_ID = "gemini-3.1-pro-preview"
-
-# tracker-097: model tiering. The bulk blog catalog (415 posts × locales) is the
-# single-block, lower-stakes path — generate it on Gemini 2.5 Flash (~6.7× cheaper
-# input / ~4.8× cheaper output than Pro, and supports thinking_budget=0). The
-# high-value designed pages (static landing + courses + housing 4-part) stay on Pro.
-# QA gate is the quality backstop: a weak Flash summary is demoted to MANUAL_REVIEW,
-# never shipped. Reversible — change this map and bump SUMMARY_PROMPT_VERSION.
-MODEL_BLOG = "gemini-2.5-flash"
-MODEL_BY_CONTENT_TYPE = {
-    "blog_post": MODEL_BLOG,
-    # course / housing / landing default to MODEL_ID (Pro) via model_for_content_type.
-}
-
-
-def model_for_content_type(content_type: str) -> str:
-    """Resolve the Gemini model for a content type (tracker-097 tiering)."""
-    return MODEL_BY_CONTENT_TYPE.get(content_type, MODEL_ID)
-
 
 # Defensive cost cap (tracker-097: 100 → 15). A run aborts if estimated cost
 # exceeds this — a real guardrail, not the old ~$100 no-op. Tunable.
@@ -135,7 +111,6 @@ LLMS_TXT_URL = "https://cel.englishcollege.com/llms.txt"
 # Filesystem layout.
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WEGLOT_IMPORTS_DIR = PROJECT_ROOT / "docs" / "admin" / "weglot-imports"
-DRYRUN_DIR = PROJECT_ROOT / "data" / "seo-intel" / "summary-dryrun"
 PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 
 # tracker-092 Phase 2: idempotency. summary-state.json maps a content id
@@ -150,32 +125,6 @@ PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 # full regeneration under the new cheaper (tiered + cached) pipeline.
 SUMMARY_PROMPT_VERSION = "2026-05-21-t098"
 SUMMARY_STATE_FILE = PROJECT_ROOT / "data" / "seo-intel" / "summary-state.json"
-
-# tracker-097: the last submitted Batch job's id + metadata, persisted on submit so a
-# cancelled/failed GHA run can `cancel-batch`/`retrieve-batch` it (a submitted Gemini
-# batch keeps billing even after the GHA run is cancelled — see RC5). Committed by the
-# workflow alongside summary-state.json so it survives across runs.
-LAST_BATCH_FILE = PROJECT_ROOT / "data" / "seo-intel" / "summary-last-batch.json"
-
-# tracker-097: explicit context-cache lifecycle. The ~6,500-token system prefix is
-# identical across every (content_type, locale, model) group; caching it drops the
-# prefix from full input rate to the cache-read rate ($0.20/M Pro, $0.03/M Flash).
-# Only groups with >= CACHE_MIN_GROUP_SIZE items are cached (a 1-item cache adds a
-# create/delete round-trip for negligible saving).
-#
-# TTL note: a Batch job runs ASYNCHRONOUSLY (1-4h typical, capped by the GHA job's
-# 6h timeout) and the cache is looked up at PROCESSING time — so the TTL must cover
-# the whole in-job batch run, NOT just submit. Caches are deleted in wait_for_batch
-# once the batch reaches a terminal state (storage is billed for actual lifetime,
-# usually << TTL); the TTL is the backstop if the run is cancelled/crashes.
-CACHE_TTL_SECONDS = 6 * 3600  # 6h — matches the GHA job timeout (covers in-job batch processing)
-CACHE_MIN_GROUP_SIZE = 2
-
-# Safety valve: the live explicit-cache path is exercised on real Gemini Batch infra
-# only (no offline test can hit it). If a run shows cache misbehaviour, set this False
-# to fall back to full-price generation without a code change. The submit path is also
-# fallback-safe per-request (a cache create/reference failure degrades to full price).
-ENABLE_EXPLICIT_CACHE = True
 
 # tracker-092 Phase 3: dedicated translator memory. Persists
 # source→translation across runs so unchanged strings are never re-translated.
@@ -226,33 +175,15 @@ AUDIT_MANUAL_REVIEW_THRESHOLD = 80
 # Translation unit — paragraph (not sentence). Matches Weglot's natural unit.
 TRANSLATION_UNIT = "paragraph"
 
-# Per-request OUTPUT-token allowance for cost estimation (2026-05-23, audit C1 fix).
-# Gemini bills THINKING tokens AS output; a Pro 4-part request spends ~3000-5000 thinking
-# + ~1500-2500 visible (the BatchRequest.max_tokens ceiling is 16000 for this reason), so
-# the old flat 800-token assumption under-projected Pro by ~6x — the root cause of the
-# ~806 TRY billing burst. Keyed by (model_family, enable_thinking). CONSERVATIVE by design:
-# over-estimating is the safe direction (it makes the cost gate stricter, not looser).
-# Flash forces thinking_budget=0, so both flash keys are visible-output only.
-OUTPUT_TOKEN_ESTIMATE = {
-    ("pro", True): 5500,    # thinking-heavy 4-part landing / courses / housing generation
-    ("pro", False): 1000,   # translation (thinking disabled) + any no-think Pro path
-    ("flash", True): 1300,  # blog single-block (Flash thinking_budget=0; margin for visible)
-    ("flash", False): 1300,
-}
-DEFAULT_OUTPUT_TOKEN_ESTIMATE = 1500
-
-# Extended thinking budget for content generation (translation passes disable thinking).
-THINKING_BUDGET_TOKENS = 1500
-
 # Webflow API base.
 WEBFLOW_API_BASE = "https://api.webflow.com/v2"
 
-# ---- Gemini config (shared) — re-exported from tools.core.gemini.config (Plan A) ----
-# These knobs are now CANONICAL in tools/core/gemini/config.py (the home the shared
-# Gemini client reads). This trailing import shadows the local definitions above so
-# summary code keeps `config.MODEL_ID` / `config.DRYRUN_DIR` etc. working off the
-# single shared source. (MAX_BATCH_COST_USD / COST_CONFIRM_THRESHOLD_USD stay
-# summary-local — the client never reads them; cli.py's cost gate does.)
+# ---- Gemini config (shared) — imported from tools.core.gemini.config (Plan A) ----
+# These knobs are CANONICAL in tools/core/gemini/config.py (the home the shared Gemini
+# client reads); summary imports them here so `config.MODEL_ID` / `config.DRYRUN_DIR`
+# etc. resolve off the single shared source. (MAX_BATCH_COST_USD /
+# COST_CONFIRM_THRESHOLD_USD stay summary-local — the client never reads them; cli.py's
+# cost gate does.)
 from tools.core.gemini.config import (  # noqa: E402,F401
     MODEL_ID, MODEL_BLOG, MODEL_BY_CONTENT_TYPE, model_for_content_type,
     OUTPUT_TOKEN_ESTIMATE, DEFAULT_OUTPUT_TOKEN_ESTIMATE, THINKING_BUDGET_TOKENS,


### PR DESCRIPTION
## Summary
Remediates the 7 minor findings from the `/review` of PR #42 (the modular `tools/core` refactor) — 5 low + 2 info, zero critical/high/medium. No behavior change to runtime paths.

- **#1/#2 docs**: `tools/core/README.md` + `docs/ARCHITECTURE.md` no longer claim a `core.webflow.http` `paginate`/`NetworkError` or `cms` `create/bulk` — none exist (pagination is in `cms.list_items`; errors raise `WebflowApiError`).
- **#3 code**: dropped the unused `content_type` param from `copywriter.prompt_builder.build_system_prompt` (+ caller).
- **#4 cosmetic**: `core/webflow/cms.py` User-Agent → `cel-webflow-client/1.0` (shared client).
- **#5 maint**: deleted the dead local Gemini-knob defs in `summary/config.py` that the trailing `core.gemini.config` import already shadowed (−89 lines; behavioral no-op).
- **#6 process**: corrected the stale PR #42 title.
- **#7 security**: added an `https://*.englishcollege.com` allowlist to `copywriter/cli.py::_resolve_before` (operator-supplied URL) + 4 regression tests.

Tracker: `docs/reviews/001-review-fix-2026-05-25.md`.

## Test plan
- [x] Full suite: 481 tests / **479 passed** / 2 known-failing (`test_update_log` sitemap host — pre-existing, out of scope) / 0 errors
- [x] `lint-imports`: 1 kept / 0 broken
- [x] `run_stress.sh`: exit 0
- [x] Phase-4a mechanical sweep: clean (no dead imports / debug markers / module-level sys.exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)