### PR TITLE
fix: remediate audit-002 findings (13 issues + 1 gap)

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -8,6 +8,7 @@ name: Stress tests (modular core + copywriter + translator)
 
 on:
   push:
+    branches: [main]   # PRs from branches trigger via pull_request only — no duplicate runs
     paths:
       - "tools/**"
       - "requirements.txt"
@@ -53,15 +54,20 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Enforce dependency-direction contract (tools.core is a leaf)
-        run: PYTHONPATH=. lint-imports
-
-      - name: Legacy + copywriter suite (-m "not stress")
+      - name: Legacy + copywriter suite (-m "not stress"), guarding the deselected known-failures
         # The 2 deselected tests are pre-existing, OUT-OF-SCOPE failures
         # (tools/test_update_log.py asserts the sitemap.* host; render() emits cel.*).
-        # The stress harness's test_00 still runs the FULL suite and bounds failures<=2,
-        # so a NEW failure here OR a regression in those 2 fails CI.
+        # First fail loudly if either node was renamed/removed (the --deselect would silently
+        # no-op). lint-imports is NOT run here — the stress step (run_stress.sh) lints, and
+        # its test_00 runs the FULL suite bounding failures<=2, so a NEW failure fails CI.
         run: |
+          set -o pipefail
+          for nid in \
+            "tools/test_update_log.py::TestRender::test_pending_shows_upload_required" \
+            "tools/test_update_log.py::TestRender::test_each_tracked_file_has_url_line"; do
+            PYTHONPATH=. python3 -m pytest "$nid" --collect-only -q >/dev/null 2>&1 \
+              || { echo "::error::deselected node missing (update the workflow): $nid"; exit 1; }
+          done
           PYTHONPATH=. python3 -m pytest tools/ -m "not stress" -p no:cacheprovider -q \
             --deselect "tools/test_update_log.py::TestRender::test_pending_shows_upload_required" \
             --deselect "tools/test_update_log.py::TestRender::test_each_tracked_file_has_url_line"

--- a/.importlinter
+++ b/.importlinter
@@ -1,9 +1,10 @@
 # Enforces the modular dependency direction for the shared-services layer:
 # tools.core.* is a LEAF — any tool may import it, but it must NEVER import a
-# consumer tool back. Run with `lint-imports` (import-linter). Satisfied today
-# (tools/core is empty) and stays green as gemini/webflow/web/content/seo land
-# under tools/core in later plans. import-linter uses static analysis (grimp), so
-# it does not execute module bodies.
+# consumer tool back. Run with `lint-imports` (import-linter). import-linter uses
+# static analysis (grimp), so it does not execute module bodies.
+# forbidden_modules MUST list EVERY consumer tool (incl. PEP-420 namespace packages
+# like tools.weglot that have no __init__.py); tools/_stress/test_50_contract_coverage.py
+# fails if a new consumer is added here without being forbidden.
 [importlinter]
 root_package = tools
 
@@ -22,3 +23,7 @@ forbidden_modules =
     tools.translator
     tools.offers
     tools.blog_images
+    tools.weglot
+    tools.arabic_rtl
+    tools.mailer
+    tools.copywriter

--- a/docs/reviews/003-audit-002-remediation-2026-05-25.md
+++ b/docs/reviews/003-audit-002-remediation-2026-05-25.md
@@ -1,0 +1,44 @@
+# Audit-002 Remediation — 2026-05-25
+
+> Remediates every finding in `docs/reviews/002-session-audit-2026-05-25.md` (1 high, 4 medium,
+> 8 low) + a small gap (G4). Web-verified the two non-obvious fixes (import-linter contract
+> type; Korean no-NLP matching). `002` left immutable as the audit record.
+
+## Status
+
+| 002 finding | Resolution | Where |
+|---|---|---|
+| **H1** contract omits consumers | `forbidden_modules` now lists all 8 consumers (added weglot/arabic_rtl/mailer/copywriter); **`weglot` is a no-`__init__.py` namespace pkg** — enforcement PROVEN by a scratch mutation-test (core→weglot ⇒ lint BROKEN). Added `test_50_contract_coverage.py` self-guard. | `.importlinter`, `tools/_stress/test_50_contract_coverage.py` |
+| **M1** flag double-count | Threshold now counts DISTINCT tells (a term in both the universal list and a locale banlist is one tell). | `tools/copywriter/qa.py` |
+| **M2** KO substring false-positive | Single-token Hangul banlist terms use a Hangul-boundary lookaround `(?<![가-힣])t(?![가-힣])` (lightweight; full correctness needs a morphological analyzer — deferred). No-op for ja/ar. | `tools/copywriter/qa.py` |
+| **M3** inert `glossary`/`sync` params | Removed from `improve_copy` (brand terms preserved via `must_keep_facts` per common.md; generation is always sync for interactive copy). README updated. | `tools/copywriter/engine.py`, `README.md` |
+| **M4** vacuous translate-spy | `test_40` now asserts the live (stubbed) path calls `generate_sync` ONCE with the `ko` locale layer in the system prompt and returns same-locale copy — proving locale-native generation, not a tautology. | `tools/_stress/test_40_locale_native.py` |
+| **L1** stale baseline 444 | → 456 (real non-stress count 462; small cushion). | `test_00_regression.py` |
+| **L2** duplicate CI runs | `push` scoped to `branches: [main]` (PRs trigger via `pull_request` only). | `.github/workflows/stress-test.yml` |
+| **L3** silent `--deselect` no-op | CI step now fails loudly if either deselected node ID was renamed/removed (`--collect-only` guard). | `.github/workflows/stress-test.yml` |
+| **L4** unbounded must-keep-fact substring | ASCII facts use an alnum-boundary `(?<![a-z0-9])f(?![a-z0-9])` (refinement over the plan's `\b`, which breaks for symbol-flanked facts like `$1,200`); non-ASCII keep substring. | `tools/copywriter/qa.py` |
+| **L5** UA drift | shared fetchers `page_fetcher`/`llms_parser` → `cel-tools/1.0` (cms.py stays `cel-webflow-client/1.0`). NOT gate-verifiable (no live fetch in tests); safe for self-fetch GETs. | `tools/core/web/page_fetcher.py`, `tools/core/seo/llms_parser.py` |
+| **L6** stale SKILL caveat | "Requires the modular-core branch on main" removed (it is on main). | `M/.claude/skills/copywriter/SKILL.md` |
+| **L7** lint resolution + redundant CI lint | `run_stress.sh` resolves lint via `command -v` (never a bare CWD name); redundant standalone CI lint step dropped (run_stress.sh lints). | `run_stress.sh`, `stress-test.yml` |
+| **L8** shim rebind fragility + banlist silent-disable | Invariant comment on the `batch_runner` shim (the only one with mutable module state); `test_qa.py` now asserts en+ko banlists parse ≥1 term (catches a renamed heading). | `tools/summary/batch_runner.py`, `test_qa.py` |
+| **G4** (gap) `_is_allowlisted_url` non-str | `isinstance(url, str)` guard + test. | `tools/copywriter/cli.py`, `test_cli.py` |
+
+## Verification
+
+```
+Full suite:   tests=486 passed=484 failed=2 errors=0   (only the 2 known test_update_log)
+Non-stress:   passed=462  (>= BASELINE_PASSED 456)
+lint-imports: 1 kept, 0 broken   (expanded forbidden list)
+run_stress.sh: exit 0
+H1 mutation-test: core→weglot import ⇒ "tools.core is not allowed to import tools.weglot" ⇒ reverted
+```
+
+Targeted proofs (all pass): M1 `"We leverage a robust platform."` → 2 distinct tells, ok=True;
+M2 `사또한테` does NOT flag `또한`, standalone tells still fail; L4 `cat`/`category`; M4 ko
+locale-layer-in-prompt assertion.
+
+## Out of scope (noted, not done)
+
+- G1: prompt (`common.md`) vs `qa.py` `_UNIVERSAL_FLAG_TERMS` banlist drift — close-but-not-identical; subjective content tuning, would churn QA fixtures.
+- The 2 pre-existing `test_update_log.py` host-assert failures (not session work).
+- Wiring a real glossary feature (the inverse of M3) — removal was the decision.

--- a/tools/_stress/run_stress.sh
+++ b/tools/_stress/run_stress.sh
@@ -17,9 +17,13 @@ PY="${STRESS_PY:-python3}"
 unset GEMINI_API_KEY WEBFLOW_API_TOKEN 2>/dev/null || true
 
 # import-linter ships only the `lint-imports` console script (no `python -m` entry).
-# Prefer the one beside the chosen interpreter; fall back to PATH.
-LINT="$(dirname "$PY")/lint-imports"
-[ -x "$LINT" ] || LINT="lint-imports"
+# Prefer the one beside the chosen interpreter; else resolve an absolute path from PATH
+# (never a bare name — that could pick up a stray ./lint-imports in the CWD).
+if [ -x "$(dirname "$PY")/lint-imports" ]; then
+  LINT="$(dirname "$PY")/lint-imports"
+else
+  LINT="$(command -v lint-imports)" || { echo "lint-imports not found on PATH"; exit 1; }
+fi
 
 echo "== import-linter (tools.core leaf contract) =="
 PYTHONPATH=. "$LINT"

--- a/tools/_stress/test_00_regression.py
+++ b/tools/_stress/test_00_regression.py
@@ -21,7 +21,7 @@ import pytest
 pytestmark = pytest.mark.stress
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BASELINE_PASSED = 444   # legacy + copywriter (excludes the stress harness). Bump on real growth.
+BASELINE_PASSED = 456   # legacy + copywriter non-stress subset (real count ~458; small cushion). Bump on real growth.
 KNOWN_FAILURES = 2      # pre-existing tools/test_update_log.py host asserts (cel vs sitemap subdomain).
 
 

--- a/tools/_stress/test_40_locale_native.py
+++ b/tools/_stress/test_40_locale_native.py
@@ -48,18 +48,27 @@ def test_improve_dry_run_never_translates(locale, _translate_spy):
     assert _translate_spy["n"] == 0      # locale-native: no translation step, ever
 
 
-def test_improve_live_path_never_translates(monkeypatch, _translate_spy):
-    """Stub the shared Gemini client so the LIVE pipeline runs offline; still no translate."""
+def test_improve_live_path_uses_locale_prompt_and_never_translates(monkeypatch, _translate_spy):
+    """The LIVE pipeline (Gemini stubbed) must call the shared client EXACTLY once with the
+    TARGET LOCALE's system prompt, return same-locale copy, and never reach the translator.
+    (M4: the old test only asserted spy==0 — vacuous, since improve_copy imports no
+    translator on any path. These positive assertions prove locale-native generation.)"""
     from tools.core.gemini import client as gemini
-    monkeypatch.setattr(
-        gemini, "generate_sync",
-        lambda reqs, **k: [gemini.BatchResult(
-            custom_id="copy-1", succeeded=True, content=_CLEAN_EN,
-            input_tokens=12, output_tokens=24)],
-    )
-    r = improve_copy(CopyRequest(brief="tighten", locale="en", existing_copy="Old draft."), dry_run=False)
-    assert r.ok is True and r.text == _CLEAN_EN
-    assert _translate_spy["n"] == 0      # the live improve path never reaches the translator
+    captured: dict = {}
+
+    def _fake_generate_sync(reqs, **k):
+        captured["reqs"] = reqs
+        return [gemini.BatchResult(custom_id="copy-1", succeeded=True, content=_CLEAN_KO,
+                                   input_tokens=12, output_tokens=24)]
+
+    monkeypatch.setattr(gemini, "generate_sync", _fake_generate_sync)
+    r = improve_copy(CopyRequest(brief="tighten", locale="ko", existing_copy="옛날 초안."), dry_run=False)
+
+    assert len(captured.get("reqs", [])) == 1          # the shared client was invoked once
+    sys_text = "\n".join(b["text"] for b in captured["reqs"][0].system_blocks)
+    assert "Locale layer (ko)" in sys_text             # ...with the KO locale layer (native)
+    assert r.ok is True and r.locale == "ko" and r.text == _CLEAN_KO  # same-locale result
+    assert _translate_spy["n"] == 0                    # translator NEVER called
 
 
 # ---------------------------------------------------------------- enforced anti-AI QA

--- a/tools/_stress/test_50_contract_coverage.py
+++ b/tools/_stress/test_50_contract_coverage.py
@@ -1,0 +1,45 @@
+"""(f) The leaf-contract must list EVERY consumer tool — self-guard against the H1 hole.
+
+audit-002 H1: `.importlinter` `forbidden_modules` had omitted `tools.copywriter` (and the
+namespace-package `tools.weglot`), so a `tools.core -> consumer` import would not have been
+caught. This test computes the live consumer set and asserts each is forbidden, so the next
+tool added without updating the contract fails HERE instead of silently widening the hole.
+
+Consumer = a `tools/<x>/` package that is importable: it has an `__init__.py` OR a
+top-level `*.py` module (PEP-420 namespace packages like `tools/weglot` have no
+`__init__.py`). Excludes the leaf itself (`core`) and the test harness (`_stress`).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.stress
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_NOT_CONSUMERS = {"core", "_stress", "__pycache__"}
+
+
+def _consumer_packages() -> set[str]:
+    out: set[str] = set()
+    for d in (REPO_ROOT / "tools").iterdir():
+        if not d.is_dir() or d.name in _NOT_CONSUMERS:
+            continue
+        if (d / "__init__.py").exists() or any(d.glob("*.py")):
+            out.add(f"tools.{d.name}")
+    return out
+
+
+def _forbidden_modules() -> set[str]:
+    text = (REPO_ROOT / ".importlinter").read_text(encoding="utf-8")
+    m = re.search(r"forbidden_modules\s*=\s*\n((?:[ \t]+\S+\n?)+)", text)
+    assert m, "could not parse forbidden_modules from .importlinter"
+    return {ln.strip() for ln in m.group(1).splitlines() if ln.strip()}
+
+
+def test_every_consumer_tool_is_forbidden_from_core():
+    missing = _consumer_packages() - _forbidden_modules()
+    assert not missing, (
+        "consumer tools missing from .importlinter forbidden_modules — the leaf-contract "
+        f"has a hole (a tools.core import of these would NOT be caught): {sorted(missing)}"
+    )

--- a/tools/copywriter/README.md
+++ b/tools/copywriter/README.md
@@ -24,9 +24,10 @@ res = improve_copy(
 # res.text / res.before / res.ok / res.qa_flags
 ```
 
-`improve_copy(req, *, glossary=None, dry_run=False, sync=True, api_key_env="GEMINI_API_KEY",
-link_candidates=())`. `dry_run=True` returns a passthrough (no spend) so wiring + the QA
-gate can be exercised offline. The live path generates → runs QA → **one** auto-retry with
+`improve_copy(req, *, dry_run=False, api_key_env="GEMINI_API_KEY", link_candidates=())`.
+`dry_run=True` returns a passthrough (no spend) so wiring + the QA gate can be exercised
+offline. (Brand/do-not-translate terms are preserved via `req.must_keep_facts`, not a
+glossary; generation is always synchronous — the copywriter is interactive, low-volume.) The live path generates → runs QA → **one** auto-retry with
 a tightened prompt on a QA fail → returns the result (a failing draft is surfaced, never
 silently written).
 

--- a/tools/copywriter/cli.py
+++ b/tools/copywriter/cli.py
@@ -28,6 +28,8 @@ from tools.copywriter.engine import improve_copy
 def _is_allowlisted_url(url: str) -> bool:
     """Only fetch over https from englishcollege.com (defensive — the target URL is
     operator-supplied via the brief; restrict the fetch surface to the known domain)."""
+    if not isinstance(url, str):
+        return False
     p = urllib.parse.urlparse(url)
     host = (p.hostname or "").lower()
     return p.scheme == "https" and (host == "englishcollege.com" or host.endswith(".englishcollege.com"))

--- a/tools/copywriter/engine.py
+++ b/tools/copywriter/engine.py
@@ -34,9 +34,7 @@ def _strip_fences(text: str) -> str:
 def improve_copy(
     req: CopyRequest,
     *,
-    glossary=None,
     dry_run: bool = False,
-    sync: bool = True,
     api_key_env: str = "GEMINI_API_KEY",
     link_candidates: Iterable[str] = (),
 ) -> CopyResult:

--- a/tools/copywriter/qa.py
+++ b/tools/copywriter/qa.py
@@ -116,11 +116,16 @@ def copywriter_qa(text: str, locale: str, *, must_keep_facts: tuple[str, ...] = 
         elif re.search(rf"\b{re.escape(term)}\b", low):
             flags.append(f"ai_term:{term}")
 
-    # --- Per-locale banlist (substring — handles agglutinative/non-Latin scripts) ---
+    # --- Per-locale banlist ---
     for term in _load_locale_banlist(locale):
         tl = term.lower()
-        if (" " in term) or not term.isascii():
-            present = term in text  # non-Latin / phrase: exact substring
+        if " " in term:
+            present = term in text  # multi-word phrase: exact substring
+        elif not term.isascii():
+            # Hangul-aware boundary: don't match a term embedded inside a longer Hangul
+            # run (사또한테 must NOT flag 또한). Lightweight heuristic — full correctness
+            # needs a morphological analyzer (deferred). No-op for non-Hangul scripts.
+            present = re.search(rf"(?<![가-힣]){re.escape(term)}(?![가-힣])", text) is not None
         else:
             present = re.search(rf"\b{re.escape(tl)}\b", low) is not None
         if present:
@@ -129,8 +134,20 @@ def copywriter_qa(text: str, locale: str, *, must_keep_facts: tuple[str, ...] = 
     # --- Fact preservation (content requirement; a miss is a hard fail) ---
     ntext = _norm(text)
     for fact in must_keep_facts:
-        if _norm(fact) and _norm(fact) not in ntext:
+        nf = _norm(fact)
+        if not nf:
+            continue
+        if nf.isascii():
+            # alnum-boundary so a short fact ("cat") isn't "found" inside a word
+            # ("category"), while still matching symbol-flanked facts ("$1,200", "DLI #O19…").
+            present = re.search(rf"(?<![a-z0-9]){re.escape(nf)}(?![a-z0-9])", ntext) is not None
+        else:
+            present = nf in ntext  # non-Latin: substring
+        if not present:
             hard_fails.append(f"missing_fact:{fact[:40]}")
 
-    ok = not hard_fails and len(flags) < _FLAG_FAIL_THRESHOLD
+    # Threshold on DISTINCT tells: a term in BOTH the universal list and a locale banlist
+    # is ONE tell, not two (M1 — double-counting was failing copy at 2 distinct tells).
+    distinct_tells = {f.split(":", 1)[1].lower() for f in flags}
+    ok = not hard_fails and len(distinct_tells) < _FLAG_FAIL_THRESHOLD
     return CopyQaReport(ok=ok, flags=flags, hard_fails=hard_fails)

--- a/tools/copywriter/tests/test_cli.py
+++ b/tools/copywriter/tests/test_cli.py
@@ -20,6 +20,8 @@ def test_is_allowlisted_url_rejects_other():
     assert not _is_allowlisted_url("https://evil.example.com/x")             # wrong host
     assert not _is_allowlisted_url("https://englishcollege.com.evil.com/x")  # suffix trick
     assert not _is_allowlisted_url("https://evil-englishcollege.com/x")      # prefix trick
+    assert _is_allowlisted_url(None) is False                                # non-str (G4)
+    assert _is_allowlisted_url(123) is False                                 # non-str (G4)
 
 
 def test_resolve_before_refuses_non_allowlisted_url(monkeypatch):

--- a/tools/copywriter/tests/test_qa.py
+++ b/tools/copywriter/tests/test_qa.py
@@ -65,3 +65,33 @@ def test_korean_clean_passes():
     txt = "대부분의 학생은 밴쿠버 캠퍼스에서 12주 풀타임 학습으로 B2 수준에 도달합니다. 주당 25시간 수업과 매일 저녁 한 시간의 자습이 전제입니다."
     r = copywriter_qa(txt, "ko")
     assert r.ok, r.summary()
+
+
+def test_overlapping_flags_count_as_one_tell():
+    # M1: 'leverage' + 'robust' are in BOTH the universal list and the en banlist, so
+    # they emit 4 flag labels but are only 2 DISTINCT tells (< 3 threshold) => passes.
+    r = copywriter_qa("We leverage a robust platform.", "en")
+    assert r.ok, r.summary()
+    assert len({f.split(":", 1)[1].lower() for f in r.flags}) == 2
+
+
+def test_korean_banlist_no_substring_false_positive():
+    # M2: '또한' is a substring of '사또한테' but must NOT flag (Hangul boundary).
+    r = copywriter_qa("사또한테 그 말을 전했어요.", "ko")
+    assert not any("또한" in f for f in r.flags), r.summary()
+    assert r.ok, r.summary()
+
+
+def test_short_fact_not_satisfied_inside_a_word():
+    # L4: 'cat' must not be considered preserved just because 'category' is present.
+    r = copywriter_qa("We run a category of courses.", "en", must_keep_facts=("cat",))
+    assert not r.ok
+    assert any(h.startswith("missing_fact") for h in r.hard_fails)
+    # but the real word IS found:
+    assert copywriter_qa("We offer a great cat program.", "en", must_keep_facts=("cat",)).ok
+
+
+def test_banlist_loads_nonempty_for_core_locales():
+    # L8: a renamed '## AI-tell banlist' heading would silently disable a locale's banlist.
+    assert len(_load_locale_banlist("en")) >= 1
+    assert len(_load_locale_banlist("ko")) >= 1

--- a/tools/core/seo/llms_parser.py
+++ b/tools/core/seo/llms_parser.py
@@ -217,7 +217,7 @@ def parse_llms_txt(text: str) -> LlmsIndex:
 
 def fetch_and_parse(url: str, timeout: float = 15.0) -> LlmsIndex:
     """Fetch llms.txt over HTTPS and parse. Raises on network or HTTP error."""
-    req = urllib.request.Request(url, headers={"User-Agent": "cel-summary-script/1.0"})
+    req = urllib.request.Request(url, headers={"User-Agent": "cel-tools/1.0"})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         text = resp.read().decode("utf-8")
     return parse_llms_txt(text)

--- a/tools/core/web/page_fetcher.py
+++ b/tools/core/web/page_fetcher.py
@@ -15,7 +15,7 @@ from html.parser import HTMLParser
 from typing import Optional
 
 
-_USER_AGENT = "cel-summary-script/1.0"
+_USER_AGENT = "cel-tools/1.0"
 _BODY_EXCERPT_MAX_CHARS = 8000
 _FETCH_TIMEOUT = 20.0
 

--- a/tools/summary/batch_runner.py
+++ b/tools/summary/batch_runner.py
@@ -10,5 +10,9 @@ tools.core.gemini.client. See docs/ARCHITECTURE.md.
 from tools.core.gemini import client as _src
 from tools.core.gemini.client import *  # noqa: F401,F403
 
+# globals().update snapshots object REFERENCES once at import. Shared mutable state
+# (e.g. _PENDING_BATCHES) stays in sync only because the core module MUTATES it in place
+# and never REBINDS it. INVARIANT: core module-level names must not be reassigned at
+# runtime, or this shim's copy would silently diverge from core's. (audit-002 L8.)
 globals().update({_k: _v for _k, _v in vars(_src).items() if not _k.startswith("__")})
 del _src


### PR DESCRIPTION
## Summary
Remediates every finding in `docs/reviews/002-session-audit-2026-05-25.md` (1 high, 4 medium, 8 low) + gap G4. Web-verified the two non-obvious fixes (import-linter contract type; Korean no-NLP matching). Tracker: `docs/reviews/003-audit-002-remediation-2026-05-25.md`.

- **H1**: `.importlinter` `forbidden_modules` now covers all 8 consumers (incl. the namespace-pkg `weglot`); enforcement proven by a scratch mutation-test; `test_50_contract_coverage.py` self-guards.
- **M1/M2/L4**: anti-AI QA counts DISTINCT tells (no double-count), Hangul-boundary match (no `또한`-in-`사또한테` false-positive), alnum-boundary must-keep-fact.
- **M3**: removed inert `glossary`/`sync` params.
- **M4**: `test_40` now proves locale-native generation (was a vacuous spy).
- **L1/L2/L3/L5/L6/L7/L8 + G4**: baseline bump, CI dedup + deselect-guard, honest UA, stale SKILL caveat, lint resolution, shim invariant comment, non-str URL guard.

## Test plan
- [x] Full suite: 486 tests / **484 passed** / 2 known-failing (`test_update_log`, out of scope) / 0 errors
- [x] Non-stress: **462 ≥ 456** baseline
- [x] `lint-imports`: 1 kept / 0 broken (expanded list); mutation-test confirms `weglot` enforced
- [x] `run_stress.sh`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)