### PR TITLE
fix: complete audit-002 out-of-scope items (suite fully green)

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -54,23 +54,12 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Legacy + copywriter suite (-m "not stress"), guarding the deselected known-failures
-        # The 2 deselected tests are pre-existing, OUT-OF-SCOPE failures
-        # (tools/test_update_log.py asserts the sitemap.* host; render() emits cel.*).
-        # First fail loudly if either node was renamed/removed (the --deselect would silently
-        # no-op). lint-imports is NOT run here — the stress step (run_stress.sh) lints, and
-        # its test_00 runs the FULL suite bounding failures<=2, so a NEW failure fails CI.
-        run: |
-          set -o pipefail
-          for nid in \
-            "tools/test_update_log.py::TestRender::test_pending_shows_upload_required" \
-            "tools/test_update_log.py::TestRender::test_each_tracked_file_has_url_line"; do
-            PYTHONPATH=. python3 -m pytest "$nid" --collect-only -q >/dev/null 2>&1 \
-              || { echo "::error::deselected node missing (update the workflow): $nid"; exit 1; }
-          done
-          PYTHONPATH=. python3 -m pytest tools/ -m "not stress" -p no:cacheprovider -q \
-            --deselect "tools/test_update_log.py::TestRender::test_pending_shows_upload_required" \
-            --deselect "tools/test_update_log.py::TestRender::test_each_tracked_file_has_url_line"
+      - name: Legacy + copywriter suite (-m "not stress")
+        # The full non-stress suite must be green (the test_update_log host asserts were
+        # corrected 2026-05-25, so the --deselect machinery is gone). lint-imports is NOT run
+        # here — the stress step (run_stress.sh, next) lints, and its test_00 re-runs the FULL
+        # suite bounding failures, so a NEW failure fails CI.
+        run: PYTHONPATH=. python3 -m pytest tools/ -m "not stress" -p no:cacheprovider -q
 
       - name: Stress harness (-m stress) — regression baseline + shim identity + compose + locale-native QA
         run: STRESS_PY=python3 bash tools/_stress/run_stress.sh

--- a/docs/reviews/003-audit-002-remediation-2026-05-25.md
+++ b/docs/reviews/003-audit-002-remediation-2026-05-25.md
@@ -37,8 +37,26 @@ Targeted proofs (all pass): M1 `"We leverage a robust platform."` → 2 distinct
 M2 `사또한테` does NOT flag `또한`, standalone tells still fail; L4 `cat`/`category`; M4 ko
 locale-layer-in-prompt assertion.
 
-## Out of scope (noted, not done)
+## Out of scope (deferred in the first remediation PR #45)
 
-- G1: prompt (`common.md`) vs `qa.py` `_UNIVERSAL_FLAG_TERMS` banlist drift — close-but-not-identical; subjective content tuning, would churn QA fixtures.
-- The 2 pre-existing `test_update_log.py` host-assert failures (not session work).
+- G1: prompt (`common.md`) vs `qa.py` `_UNIVERSAL_FLAG_TERMS` banlist drift.
+- The 2 pre-existing `test_update_log.py` host-assert failures.
 - Wiring a real glossary feature (the inverse of M3) — removal was the decision.
+
+## Follow-up — out-of-scope items completed (2026-05-25)
+
+- **G1 — DONE.** `common.md` banned-word list synced to `qa.py`: added `consequently`, `notably`,
+  `embark` (QA flagged them; the prompt didn't warn). Prompt now warns about everything QA
+  enforces, so the model isn't blind-sided into a QA-fail retry. Prompt-only; no fixture churn.
+- **`test_update_log` — DONE (suite now fully green).** The 2 stale assertions
+  (`sitemap.englishcollege.com`) were corrected to the canonical `cel.englishcollege.com` —
+  what `update_log.render()` actually emits (the code was right per the canonical-sitemap rule;
+  the tests were stale). Cascade: `KNOWN_FAILURES 2→0`, `BASELINE_PASSED 456→462`, and the CI
+  `--deselect` machinery + its existence-guard removed (no longer needed). Full suite: **486
+  passed / 0 failed**.
+- **M2 (Korean) — intentionally deferred, not a bug.** A full fix needs a morphological analyzer
+  (KoNLPy/mecab) — a heavy dependency deferred by an earlier locked decision. The Hangul-boundary
+  heuristic + the ≥3-distinct-tell threshold is the accepted lightweight state.
+- **L5 (UA) — unverifiable by design.** The live fetch isn't exercised in tests (no-network); the
+  `cel-tools/1.0` change is safe for a self-fetch GET but can't be gate-proven without a live call.
+- Glossary feature: still intentionally NOT wired (removal stands — brand terms via `must_keep_facts`).

--- a/tools/_stress/test_00_regression.py
+++ b/tools/_stress/test_00_regression.py
@@ -21,8 +21,8 @@ import pytest
 pytestmark = pytest.mark.stress
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BASELINE_PASSED = 456   # legacy + copywriter non-stress subset (real count ~458; small cushion). Bump on real growth.
-KNOWN_FAILURES = 2      # pre-existing tools/test_update_log.py host asserts (cel vs sitemap subdomain).
+BASELINE_PASSED = 462   # legacy + copywriter non-stress subset (real count 464; small cushion). Bump on real growth.
+KNOWN_FAILURES = 0      # suite is fully green (the test_update_log host asserts were corrected 2026-05-25).
 
 
 def test_legacy_suite_passed_count_at_or_above_baseline(tmp_path):

--- a/tools/copywriter/prompts/common.md
+++ b/tools/copywriter/prompts/common.md
@@ -28,7 +28,7 @@ It sets the language's register, punctuation, number/date conventions, and a lan
 ## HARD BANS — these make copy read AI-generated. Do not use them.
 - **No em dashes (— or –).** Use commas, periods, parentheses, or restructure.
 - **No emoji. No Title-Case headings. No bold-on-every-key-term.**
-- **No AI cliché words:** delve, leverage, robust, seamless, elevate, unlock, foster, holistic, tapestry, multifaceted, cutting-edge, game-changer, transformative, furthermore, moreover, additionally, underscore, utilize, harness, nestled, vibrant, pivotal, "navigate the landscape".
+- **No AI cliché words:** delve, leverage, robust, seamless, elevate, unlock, foster, holistic, tapestry, multifaceted, cutting-edge, game-changer, transformative, furthermore, moreover, additionally, consequently, notably, underscore, utilize, harness, embark, nestled, vibrant, pivotal, "navigate the landscape".
 - **No hedging/signposting:** "it's important to note", "it's worth noting", "when it comes to", "in the realm of", "needless to say", "in conclusion".
 - **No opener clichés:** "In today's fast-paced world", "In the era of", "In a world where", "Let's dive in", "Picture this".
 - **No AI sentence templates:** "It's not just X, it's Y", "Not only X but also Y", "From X to Y" as filler, rule-of-three lists, participial tails ("…, ensuring…", "…, allowing you to…"), copula-avoidance ("serves as", "stands as", "represents a") — just say "is".

--- a/tools/test_update_log.py
+++ b/tools/test_update_log.py
@@ -125,7 +125,7 @@ class TestRender:
         }
         output = render(entries, pending=4, weglot_last_check="2026-04-16 09:07 GMT+3")
         assert "Upload to Weglot: REQUIRED" in output
-        assert "sitemap.englishcollege.com/weglot.csv" in output
+        assert "cel.englishcollege.com/weglot.csv" in output
 
     def test_cleared_shows_not_required(self):
         entries = {
@@ -153,9 +153,9 @@ class TestRender:
     def test_each_tracked_file_has_url_line(self):
         entries = {k: "2026-04-16 17:00 GMT+3" for k in ("sitemap.xml", "llms.txt", "weglot.csv")}
         output = render(entries, pending=0, weglot_last_check="2026-04-16 09:07 GMT+3")
-        assert "URL: https://sitemap.englishcollege.com/sitemap.xml" in output
-        assert "URL: https://sitemap.englishcollege.com/llms.txt" in output
-        assert "URL: https://sitemap.englishcollege.com/weglot.csv" in output
+        assert "URL: https://cel.englishcollege.com/sitemap.xml" in output
+        assert "URL: https://cel.englishcollege.com/llms.txt" in output
+        assert "URL: https://cel.englishcollege.com/weglot.csv" in output
 
     def test_last_weglot_check_line_present(self):
         entries = {k: "2026-04-16 17:00 GMT+3" for k in ("sitemap.xml", "llms.txt", "weglot.csv")}


### PR DESCRIPTION
## Summary
Completes the items parked as out-of-scope in the audit-002 remediation (PR #45), per follow-up request. Tracker: `docs/reviews/003-audit-002-remediation-2026-05-25.md` (Follow-up section).

- **G1**: synced the copywriter prompt's banned-word list (`common.md`) to `qa.py` — added `consequently`, `notably`, `embark` (QA flagged them, the prompt didn't warn). Prompt-only.
- **test_update_log**: corrected the 2 stale assertions (`sitemap.englishcollege.com` → the canonical `cel.englishcollege.com` that `update_log.render()` emits — the code was right, the tests were stale). **The suite is now 0-failure.**
- **Cascade**: `KNOWN_FAILURES 2→0`, `BASELINE_PASSED 456→462`; removed the CI `--deselect` machinery + its guard (no longer needed).
- **M2** (needs KoNLPy/mecab) + **L5** (UA not gate-verifiable) documented as intentionally deferred.

## Test plan
- [x] Full suite: **486 passed / 0 failed / 0 errors** (first all-green CEL run)
- [x] Non-stress: **464 ≥ 462** baseline
- [x] `lint-imports`: 1 kept / 0 broken
- [x] `run_stress.sh`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)