### PR TITLE
chore: add Claude tooling — CLAUDE.md, /preflight, no-spend guards

### DIFF
--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,0 +1,32 @@
+---
+description: Run the full read-only gate set (legacy tests + import-linter + stress + workflow lint) before pushing. No spend, never lowers the baseline.
+allowed-tools: Bash(python3:*), Bash(.venv*/bin/python:*), Bash(pytest:*), Bash(bash tools/_stress/run_stress.sh:*), Bash(lint-imports:*), Bash(scripts/lint_workflows.py:*)
+---
+
+Run the repo's gates in order and report a clear PASS/FAIL for each. These are all read-only and
+**never spend** (the stress harness unsets the Gemini/Webflow keys). Do NOT "fix" a failure by lowering
+`BASELINE_PASSED` or raising `KNOWN_FAILURES` in `tools/_stress/test_00_regression.py` — those are the
+guard; echo the live baseline on failure instead.
+
+Pick the interpreter once (prefer an active venv): use `.venv/bin/python` or `.venv313/bin/python` if it
+exists, else `python3`. Export it as `PY` and pass `STRESS_PY=$PY` to the stress harness.
+
+1. **Legacy suite** (no spend):
+   `$PY -m pytest tools/ -m "not stress" -p no:cacheprovider -q`
+2. **Stress harness** (import-linter leaf contract + stress suite, keys unset inside the script):
+   `STRESS_PY=$PY bash tools/_stress/run_stress.sh`
+3. **Workflow lint** (strict — fail on medium+):
+   `$PY scripts/lint_workflows.py --strict`
+
+After running all three, print a summary table:
+
+```
+gate                  result
+legacy suite          PASS / FAIL (passed=NN, baseline=462)
+stress + leaf         PASS / FAIL
+workflow lint --strict PASS / FAIL
+```
+
+If anything fails, show the relevant tail of output and STOP — do not push. If a test count dipped below
+`BASELINE_PASSED = 462`, say so explicitly and treat it as a regression to investigate, never as a number
+to edit down.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/pretool-no-spend-warn.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md — standing rules for this repo (CEL tools)
+
+Python automation + SEO-asset deployment for **englishcollege.com** (Canadian English Language
+College / "CEL"), git repo `cagdasunal/CEL`. A fleet of GitHub Actions crons drives Webflow CMS
+content, Weglot translation exclusions, blog-image optimization, offers automation, and SEO
+summaries/copywriting. The canonical design doc is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) —
+read it first for anything touching `tools/`.
+
+## The five things that must never drift
+
+1. **The runtime LLM is Gemini, NOT Claude.** Every model call at runtime goes to Google Gemini
+   (`tools/core/gemini/config.py`: `MODEL_ID = "gemini-3.1-pro-preview"`, blog `gemini-2.5-flash`).
+   Claude (you) is the *dev* assistant only — never wire Claude/Anthropic into the runtime, and never
+   assume a model call here is Claude.
+
+2. **No-spend by default — `dry_run` is the safe default and must stay that way.** The shared Webflow
+   client defaults to dry-run: `tools/core/webflow/cms.py` `CmsClient.__init__(..., dry_run: bool = True)`.
+   A real spend / real Webflow write happens ONLY when a caller explicitly passes `dry_run=False` (or
+   removes it) and supplies keys. **Never remove a `dry_run=True` from existing call sites** to "make it
+   work" — that turns a safe test into real spend. During any build/refactor: dry-run + mocks only, no
+   live API/Webflow calls (ARCHITECTURE.md "Global execution protocol" §5).
+
+3. **Claude never publishes.** Publishing to Webflow is explicit human opt-in: the `summary` CLI gates
+   it behind `--publish` (`action="store_true", default=False`). Do not add an auto-publish path, do not
+   default `--publish` on, and do not run a publish command on the owner's behalf without being told to.
+
+4. **`tools.core.*` is a leaf — the dependency direction is a test, not a comment.** Any tool may import
+   `tools.core.*`; `tools.core` must NEVER import a consumer tool (`summary`, `translator`, `copywriter`,
+   `offers`, `weglot`, `blog_images`, `arabic_rtl`, `mailer`). Enforced by import-linter
+   (`.importlinter` contract `core-is-a-leaf`; run `lint-imports`). If you add a new leaf under
+   `tools/core/`, add it to `source_modules`; if you add a new consumer tool, add it to
+   `forbidden_modules` (`test_50_contract_coverage.py` fails otherwise).
+
+5. **The regression baseline is a floor, not a guess.** `tools/_stress/test_00_regression.py` pins
+   `BASELINE_PASSED = 462` and `KNOWN_FAILURES = 0` (suite is fully green). Bump `BASELINE_PASSED`
+   *deliberately* only when the suite legitimately grows; never lower it or raise `KNOWN_FAILURES` to get
+   to green — that defeats the guard. If you cite the baseline, cite the live numbers from that file.
+
+## Sibling repo
+
+A sibling Webflow checkout lives at `~/Desktop/dev/webflow` (`cagdasunal/webflow`). Some assets/workflows
+are kept in step between the two. There is **no formal mirror manifest in this repo** — do not assume a
+file here is the source of truth for the sibling (or vice-versa). When in doubt about which side owns a
+mirrored file, ask before editing; do not blindly copy in either direction.
+
+## How to work here
+
+- **Env:** a venv with `requirements.txt`. CI uses Python 3.12; local dev may use 3.13 (`.venv` or
+  `.venv313`). `pyproject.toml` sets `pythonpath`, `testpaths`, and the `stress`/`eval` markers.
+- **Tests:** `pytest tools/ -q` (full) · `pytest -m "not stress"` (legacy only) · `pytest -m stress`
+  (deterministic mocked cross-tool harness — no spend, safe in CI). `lint-imports` enforces the leaf
+  contract. The `eval` marker is real-spend and runs manually, never in CI.
+- **`/preflight`** chains the read-only gates (legacy tests + `lint-imports` + stress + workflow lint).
+  Run it before pushing. It never spends and never lowers the baseline.
+- **Workflows:** lint them with `python scripts/lint_workflows.py --strict` (default threshold is high+;
+  `--strict` fails on medium+).
+- **Branch + revert:** one change per branch/commit with its own green gate; rollback = `git revert`
+  (ARCHITECTURE.md "Global execution protocol").
+
+## Pointers
+
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — the canonical design (layout, the leaf rule, extraction
+  pattern, testing, execution protocol). When this file disagrees with ARCHITECTURE.md on `tools/`
+  internals, ARCHITECTURE.md wins and this file gets fixed.
+- `.github/workflows/` — the cron fleet (summary, content-pipeline, weglot-sync, offers-*, blog-image,
+  arabic-css, sitemap-llms, stress-test, lint-workflows).

--- a/scripts/hooks/check-no-spend.sh
+++ b/scripts/hooks/check-no-spend.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# No-spend guard — fails if a staged diff REMOVES a `dry_run=True` default/argument.
+#
+# Why: the whole repo is "safe by default" because callers pass dry_run=True (and the shared
+# CmsClient defaults to it). Silently dropping a `dry_run=True` turns a safe test or staged write
+# into REAL Webflow spend. This guard catches that in the diff, for the human and for Claude.
+#
+# Scope: it only flags REMOVED lines (leading `-`) that contain `dry_run=True` or `dry_run = True`,
+# excluding this script itself. Adding/keeping dry_run is always fine. A deliberate go-live (removing
+# dry_run on purpose) can be allowed with: ALLOW_REMOVE_DRY_RUN=1 git commit ...
+#
+# Install as a pre-commit hook:
+#   ln -sf ../../scripts/hooks/check-no-spend.sh .git/hooks/pre-commit
+# or call it from /preflight / CI.
+set -euo pipefail
+
+if [ "${ALLOW_REMOVE_DRY_RUN:-0}" = "1" ]; then
+  echo "no-spend guard: bypassed via ALLOW_REMOVE_DRY_RUN=1 (deliberate go-live)."
+  exit 0
+fi
+
+# Staged diff only; if not in a commit context, diff the working tree against HEAD.
+if git rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  DIFF="$(git diff --cached -U0 -- '*.py' 2>/dev/null || true)"
+else
+  DIFF="$(git diff --cached -U0 -- '*.py' 2>/dev/null || true)"
+fi
+
+# Removed lines start with a single '-' (not '---'); look for a dry_run=True default being deleted.
+OFFENDERS="$(printf '%s\n' "$DIFF" \
+  | grep -E '^-[^-]' \
+  | grep -E 'dry_run[[:space:]]*=[[:space:]]*True' \
+  | grep -v 'scripts/hooks/check-no-spend.sh' || true)"
+
+if [ -n "$OFFENDERS" ]; then
+  echo "ERROR: this commit REMOVES a 'dry_run=True' default — that can turn a safe call into real spend." >&2
+  echo "Removed lines:" >&2
+  printf '%s\n' "$OFFENDERS" >&2
+  echo >&2
+  echo "If this go-live is intentional, re-run with:  ALLOW_REMOVE_DRY_RUN=1 git commit ..." >&2
+  exit 1
+fi
+
+echo "no-spend guard: OK (no dry_run=True default removed)."
+exit 0

--- a/scripts/hooks/pretool-no-spend-warn.sh
+++ b/scripts/hooks/pretool-no-spend-warn.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PreToolUse WARN hook (never blocks) — warns when an edit writes `dry_run=False` into a .py file.
+#
+# Reads the PreToolUse payload as JSON on stdin (the stable hook contract) and inspects the edit
+# content. Writing dry_run=False enables real spend / real Webflow writes — almost always you want a
+# test to keep dry_run=True. This only WARNS (exit 0, message on stderr); it never denies, so a
+# deliberate go-live or an `eval` real-model run is never blocked. CLAUDE.md rule 2 + CI stay the
+# source of truth.
+#
+# Wired via .claude/settings.json PreToolUse (matcher Edit|Write|MultiEdit).
+set -euo pipefail
+
+payload="$(cat 2>/dev/null || true)"
+[ -z "$payload" ] && exit 0
+
+# Pull the target path + the new content, tolerating Edit/Write/MultiEdit shapes. python3 is always
+# present here; jq may not be.
+read -r path content <<EOF2
+$(printf '%s' "$payload" | python3 -c '
+import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+ti=d.get("tool_input",{}) or {}
+path=ti.get("file_path","") or ""
+parts=[ti.get("new_string",""), ti.get("content","")]
+for e in ti.get("edits",[]) or []:
+    parts.append(e.get("new_string",""))
+content=" ".join(p for p in parts if p)
+print(path, content.replace("\n"," "))
+' 2>/dev/null)
+EOF2
+
+case "$path" in
+  *.py) ;;
+  *) exit 0 ;;
+esac
+
+if printf '%s' "$content" | grep -Eq 'dry_run[[:space:]]*=[[:space:]]*False'; then
+  echo "WARN: this edit writes 'dry_run=False' into $path — that enables REAL spend / Webflow writes." >&2
+  echo "      Confirm it's a deliberate go-live, not a test edit. No-spend default is dry_run=True (CLAUDE.md rule 2)." >&2
+fi
+exit 0


### PR DESCRIPTION
Adopts ECC-style agent-harness conventions (from a review of [affaan-m/ECC](https://github.com/affaan-m/ECC)). All additive, no runtime/CI behavior change.

## What's in here
- **`CLAUDE.md`** — pins the 5 invariants: runtime LLM is **Gemini, not Claude**; `dry_run` no-spend default; Claude-never-publishes; `tools.core` leaf contract; the **462/0** regression baseline as a floor. Links `docs/ARCHITECTURE.md` as canonical.
- **`.claude/commands/preflight.md`** — chains the existing gates (legacy tests + import-linter + stress harness + workflow lint). Read-only, no spend, never lowers the baseline.
- **`scripts/hooks/check-no-spend.sh`** — pre-commit guard; fails if a staged diff removes a `dry_run=True` default (`ALLOW_REMOVE_DRY_RUN=1` to override a deliberate go-live).
- **`scripts/hooks/pretool-no-spend-warn.sh`** + `.claude/settings.json` — PreToolUse **WARN** (never deny) when an edit writes `dry_run=False` into a `.py` file.

## Verification
All hook paths tested (warn / quiet / override); `settings.json` validated; baseline confirmed against `tools/_stress/test_00_regression.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)