### PR TITLE
fix(blog-autopilot): bound the whole run so it stops timing out at the 60-min cap

### DIFF
--- a/.github/workflows/blog-summary-autopilot.yml
+++ b/.github/workflows/blog-summary-autopilot.yml
@@ -11,14 +11,17 @@ name: Blog summary autopilot (new posts → native-language summary, live)
 # posts are summarized. Blog uses the cheap Flash model; --sync runs them inline
 # (no Batch API wait).
 #
-# First-run BACKFILL is bounded (tracker-138, 2026-07-09): the state file starts with
-# no blog entries, so run #1 has the whole back-catalog (~142 posts) to summarize.
-# generate_sync bounds each call (hard 4-min timeout) AND stops at a per-run budget
-# (config.SYNC_RUN_DEADLINE_SEC, 40 min — under the 60-min cap), then returns partial.
-# The commit step below checkpoints summary-state.json, so the NEXT run resumes on the
-# remainder. The backlog drains over a few daily runs; steady state is a fast no-op.
-# (Before this fix run #1 tried all ~142 sequentially, was SIGKILLed at the 60-min cap
-# before it could checkpoint, and the autopilot never once succeeded.)
+# First-run BACKFILL is bounded (tracker-138, PERMANENT fix 2026-07-13): the state file starts
+# with no blog entries, so run #1 has the whole back-catalog (~142 posts) to summarize. The WHOLE
+# run is bounded by TWO shared wall-clock deadlines (config.GENERATE_DEADLINE_SEC 35m for both
+# generate passes, config.RUN_DEADLINE_SEC 45m for write-back — generation stops earlier so it can't
+# starve write-back) plus a hard watchdog (config.RUN_WATCHDOG_HARD_SEC 52m) that force-exits before
+# the 60-min cap. Write-back checkpoints summary-state.json INCREMENTALLY (per written item), and the
+# commit step below runs on always(), so the NEXT run resumes on the remainder. The backlog drains
+# over a few daily runs; steady state is a fast no-op. (The 2026-07-09 first cut bounded only ONE
+# generate_sync call — the retry pass got a fresh budget and write-back was unbounded — so run #1
+# still rode past the 60-min cap, was SIGKILLed before it could checkpoint, and the autopilot timed
+# out EVERY day for 6+ weeks and never once succeeded.)
 #
 # Scope guarantees:
 #   - --collection blog       → never touches courses / housing / static pages.
@@ -62,7 +65,8 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # BACKSTOP only — generate_sync self-limits to config.SYNC_RUN_DEADLINE_SEC (40m); tracker-138.
+    timeout-minutes: 60  # OUTER cap only — the run self-limits cooperatively (config.RUN_DEADLINE_SEC 45m) with a
+                         # hard in-process watchdog (config.RUN_WATCHDOG_HARD_SEC 52m) below it; tracker-138.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -124,6 +128,13 @@ jobs:
           if-no-files-found: ignore
 
       - name: Commit idempotency state + summaries manifest
+        # tracker-138 (2026-07-13): `always()` so a PARTIAL run still checkpoints. The generate step
+        # writes summary-state.json INCREMENTALLY (per item written), and the in-process watchdog force-exits
+        # 0 before the 60-min cap — but if a run is still somehow cancelled/killed, this step must STILL commit
+        # whatever progress reached disk, or the backlog never drains (the 6-week daily-timeout root cause: the
+        # end-only save + a non-`always` commit meant every timeout discarded all progress). Atomic writes make
+        # a mid-run snapshot safe to commit; "nothing to commit" is a clean no-op.
+        if: ${{ always() }}
         run: |
           set -o pipefail
           git config user.name "github-actions[bot]"

--- a/tools/summary/cli.py
+++ b/tools/summary/cli.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -459,13 +462,19 @@ def _execute_batch_recovery(args: argparse.Namespace, out_dir: Path) -> int:
 # without the google-genai SDK installed.
 
 
-def _submit_and_wait(requests: list, args: argparse.Namespace):
+def _submit_and_wait(requests: list, args: argparse.Namespace, run_deadline: Optional[float] = None):
     """Run a batch of requests and collect results (tracker-097).
 
     --sync: one synchronous generate_sync over all requests (per-request model).
     Batch (default): group requests by resolved model and run one Batch job per
     model — the Batch API accepts a single model per job, so tiering (blog → Flash,
     rest → Pro) requires per-model jobs. Returns (results, primary_handle, batch_ids).
+
+    tracker-138 (2026-07-13): `run_deadline` is an ABSOLUTE time.monotonic() timestamp shared
+    across the WHOLE run. Every generate_sync pass (the main pass AND the retry pass) is bounded
+    by the REMAINING budget to that one deadline — so the retry can no longer get a fresh 40-min
+    budget and ride the run past the 60-min job cap. Falls back to the legacy per-call budget only
+    when no run-deadline is threaded (e.g. a unit test calling this directly).
     """
     from tools.summary import batch_runner
 
@@ -474,10 +483,12 @@ def _submit_and_wait(requests: list, args: argparse.Namespace):
             batch_id=f"sync-{_timestamp_slug()}", request_count=len(requests),
             submitted_at=_now_iso(), dry_run=False,
         )
+        remaining = (
+            max(1.0, run_deadline - time.monotonic())
+            if run_deadline is not None else config.SYNC_RUN_DEADLINE_SEC
+        )
         return (
-            batch_runner.generate_sync(
-                requests, run_deadline_sec=config.SYNC_RUN_DEADLINE_SEC
-            ),
+            batch_runner.generate_sync(requests, run_deadline_sec=remaining),
             handle,
             [handle.batch_id],
         )
@@ -563,6 +574,35 @@ def _execute_purge_stale_rows(args: argparse.Namespace, out_dir: Path) -> int:
     return 0
 
 
+_WATCHDOG_EXIT_CODE = 2  # non-zero: a watchdog fire is an ABNORMAL hang worth alerting (see _start_run_watchdog).
+
+
+def _start_run_watchdog(hard_sec: float) -> "threading.Timer":
+    """Defense-in-depth backstop (tracker-138): if the whole run hangs past ``hard_sec`` — a stuck
+    network read, an unforeseen loop — a daemon timer force-exits the process rather than let it ride the
+    job cap to a SIGKILL. The NORMAL bounded run stops COOPERATIVELY at the generate/run deadlines and exits
+    0 on its own well before this, so the watchdog only ever fires on a genuine hang the cooperative stops
+    did NOT catch. That is an abnormal condition, so it exits NON-ZERO (``_WATCHDOG_EXIT_CODE``) — which is
+    what makes the workflow's "Notify on failure" step fire; exiting 0 here (the first cut of this fix) would
+    have re-created the exact silent-hang the alert exists to prevent. Durability does NOT depend on the exit
+    code: write-back has already checkpointed summary-state.json INCREMENTALLY, and the commit step runs on
+    ``always()``, so the backlog still drains AND the owner is told a run hung. Daemon so it never blocks a
+    normal exit (a run that finishes first discards it at interpreter shutdown). Returns the started Timer.
+    """
+    def _fire() -> None:
+        print(
+            f"[summary] run watchdog: exceeded {hard_sec:.0f}s hard budget — a phase HUNG past the cooperative "
+            f"deadlines. Exiting {_WATCHDOG_EXIT_CODE} (alert) with progress already checkpointed; investigate.",
+            file=sys.stderr, flush=True,
+        )
+        os._exit(_WATCHDOG_EXIT_CODE)  # immediate; the incremental checkpoint is already on disk (+ always()-commit).
+
+    t = threading.Timer(hard_sec, _fire)
+    t.daemon = True
+    t.start()
+    return t
+
+
 def _execute_generate_english(args: argparse.Namespace, out_dir: Path) -> dict[str, Any]:
     """Execute generate-english phase. Returns metadata for the report."""
     from tools.summary import batch_runner, llms_parser
@@ -571,6 +611,22 @@ def _execute_generate_english(args: argparse.Namespace, out_dir: Path) -> dict[s
     from tools.summary.prompt_builder import (
         KeywordPlan, SourceItem, build_system_prompt, build_user_message,
     )
+
+    # tracker-138 (2026-07-13): TWO shared wall-clock deadlines for the whole live run, plus a hard watchdog.
+    # generate_deadline (both generate passes) fires EARLIER than run_deadline (write-back) so a large first-run
+    # backlog cannot consume the whole budget and STARVE write-back — the failure that left items generated but
+    # never written or checkpointed. The reserved gap lets write-back persist what this run generated.
+    # SCOPE: only the --sync path (the interactive autopilot, which runs under a ~60-min CI cap) is bounded.
+    # A DEFAULT (Batch API) run legitimately takes up to the 24h batch SLA, so bounding it — or the watchdog
+    # force-exiting it at 52 min — would be wrong; batch runs stay unbounded. Dry-run also opts out (no network,
+    # no cap). When they opt out the deadlines stay None → every phase runs unbounded, exactly as today.
+    generate_deadline: Optional[float] = None
+    run_deadline: Optional[float] = None
+    if not args.dry_run and getattr(args, "sync", False):
+        _now = time.monotonic()
+        generate_deadline = _now + config.GENERATE_DEADLINE_SEC
+        run_deadline = _now + config.RUN_DEADLINE_SEC
+        _start_run_watchdog(config.RUN_WATCHDOG_HARD_SEC)
 
     plan = _plan_generate_english(args)
     items_to_process: list[dict[str, Any]] = []
@@ -839,7 +895,7 @@ def _execute_generate_english(args: argparse.Namespace, out_dir: Path) -> dict[s
     # Live run. _submit_and_wait: --sync = instant generate_sync (per-request model);
     # else group requests by model and run one Batch job per model (the Batch API
     # takes a single model per job — tracker-097 tiering).
-    results, handle, batch_ids = _submit_and_wait(requests, args)
+    results, handle, batch_ids = _submit_and_wait(requests, args, run_deadline=generate_deadline)
     # M5 (2026-05-23): surface silently-failed cache creates — a cache that didn't engage
     # means full-rate input billing with no signal (a burst contributor).
     _cache_create_failures = getattr(handle, "cache_create_failures", 0)
@@ -868,7 +924,7 @@ def _execute_generate_english(args: argparse.Namespace, out_dir: Path) -> dict[s
                     )
                 )
         if retry_requests:
-            retry_results, _retry_handle, _retry_ids = _submit_and_wait(retry_requests, args)
+            retry_results, _retry_handle, _retry_ids = _submit_and_wait(retry_requests, args, run_deadline=generate_deadline)
             for rr in retry_results:
                 if rr.succeeded:
                     succeeded.append(rr)
@@ -972,26 +1028,32 @@ def _execute_generate_english(args: argparse.Namespace, out_dir: Path) -> dict[s
     )
     # Write the EN-summaries manifest for the translate phase to read.
     mpath, mcount = _write_en_summaries_manifest(succeeded, sources)
-    # Write back. Static pages → JSON. CMS items → Webflow API.
-    write_log = _write_back_summaries(succeeded, sources, args, out_dir, warnings)
-
-    # tracker-092 (2.1): persist idempotency state for successfully written items
-    # so the next run skips them while their source content is unchanged.
-    if not args.dry_run:
-        for r in succeeded:
-            base = r.custom_id[len("retry-"):] if r.custom_id.startswith("retry-") else r.custom_id
-            mapped = _src_by_cid.get(base)
-            if mapped:
-                sitem = mapped[0]
-                cid_key = sitem.cms_item_id or sitem.url
-                summary_state[cid_key] = {
-                    "source_hash": _source_hash(
-                        sitem.body_excerpt, cid_key,
-                        config.model_for_content_type(sitem.content_type),
-                    ),
-                    "generated_at": _now_iso(),
-                }
+    # tracker-092 (2.1) + tracker-138 (2026-07-13): persist idempotency state per item AS IT IS WRITTEN,
+    # not once at the end. Two reasons: (1) DURABILITY — the run is bounded by a wall-clock deadline, so it
+    # can stop partway; an end-only save meant a SIGKILL (or the watchdog) lost EVERYTHING and the backlog
+    # never drained (the 6-week incident). Incremental + atomic saves mean progress up to the last written
+    # item always survives and the CI commit step persists it. (2) CORRECTNESS — checkpoint ONLY items whose
+    # Webflow write actually SUCCEEDED (the old end-loop marked every generated item done, so an item that
+    # FAILED to write was skipped forever). The callback fires from inside the write loop on each success.
+    def _checkpoint_written(sitem) -> None:
+        if args.dry_run:
+            return
+        cid_key = sitem.cms_item_id or sitem.url
+        summary_state[cid_key] = {
+            "source_hash": _source_hash(
+                sitem.body_excerpt, cid_key,
+                config.model_for_content_type(sitem.content_type),
+            ),
+            "generated_at": _now_iso(),
+        }
         _save_summary_state(summary_state)
+
+    # Write back. Static pages → JSON. CMS items → Webflow API. Bounded by the shared run deadline (stops
+    # STARTING new writes past it and publishes what it already wrote) and checkpoints each written item.
+    write_log = _write_back_summaries(
+        succeeded, sources, args, out_dir, warnings,
+        run_deadline=run_deadline, on_written=_checkpoint_written,
+    )
 
     # tracker-092 (2.4): observability — flag the run as degraded when a critical
     # input failed (llms.txt unreachable, or a source page/collection fetch failed),
@@ -1953,8 +2015,15 @@ def _execute_translate_meta(args: argparse.Namespace, out_dir: Path) -> dict[str
 
 def _write_back_summaries(
     succeeded: list, sources: list, args: argparse.Namespace, out_dir: Path, warnings: list[str],
+    run_deadline: Optional[float] = None, on_written=None,
 ) -> dict[str, Any]:
-    """Write generated summaries to Webflow CMS (CMS items) or to JSON files (static pages)."""
+    """Write generated summaries to Webflow CMS (CMS items) or to JSON files (static pages).
+
+    tracker-138 (2026-07-13): ``run_deadline`` (an absolute time.monotonic() timestamp) bounds the write
+    loop — past it we STOP starting new writes and fall through to publish + return whatever was written,
+    so the whole run stays under the job cap. ``on_written(item)`` is invoked after each SUCCESSFUL write
+    so the caller can checkpoint idempotency state incrementally (durable across an early stop).
+    """
     from tools.summary.structure import (
         four_part_content_html,
         four_part_paragraph_html,
@@ -1969,6 +2038,7 @@ def _write_back_summaries(
     cms_writes = 0
     static_writes = 0
     failures = 0
+    deferred = 0
     # --publish (autopilot): the item ids successfully written this run, grouped by
     # collection, so we can publish ONLY them to LIVE after the write loop.
     written_by_collection: dict[str, list[str]] = {}
@@ -1978,6 +2048,16 @@ def _write_back_summaries(
         for i, (item, _kw, target) in enumerate(sources)
     }
     for result in succeeded:
+        # tracker-138: stop STARTING new writes past the shared run deadline. The items already written
+        # this pass still get published + checkpointed below; the rest are deferred to the next run (their
+        # idempotency state was never set, so they are simply re-picked-up — no loss, no double-write).
+        if run_deadline is not None and time.monotonic() >= run_deadline:
+            deferred = len(succeeded) - (cms_writes + static_writes + failures)
+            warnings.append(
+                f"run deadline reached during write-back: wrote {cms_writes + static_writes}, "
+                f"deferred {deferred} to the next run."
+            )
+            break
         cid = result.custom_id
         if cid.startswith("retry-"):
             cid = cid[len("retry-"):]
@@ -1993,6 +2073,8 @@ def _write_back_summaries(
             wr = write_static_summary_parts(item.url, parts, static_dir, dry_run=args.dry_run)
             if wr.success:
                 static_writes += 1
+                if on_written is not None:
+                    on_written(item)
             else:
                 failures += 1
                 warnings.append(f"static write failed: {item.url}: {wr.error}")
@@ -2040,6 +2122,8 @@ def _write_back_summaries(
                 written_by_collection.setdefault(
                     _collection_id_for_content_type(item.content_type), []
                 ).append(item.cms_item_id)
+                if on_written is not None:
+                    on_written(item)
             else:
                 failures += 1
                 warnings.append(f"cms write failed for {item.cms_item_id}: {wresult.error}")
@@ -2065,7 +2149,7 @@ def _write_back_summaries(
 
     return {
         "cms_writes": cms_writes, "static_writes": static_writes, "failures": failures,
-        "publish": publish_log,
+        "deferred": deferred, "publish": publish_log,
     }
 
 

--- a/tools/summary/config.py
+++ b/tools/summary/config.py
@@ -20,16 +20,31 @@ MAX_BATCH_COST_USD = 15
 # go-ahead" is the human layer; this is the code-level backstop.
 COST_CONFIRM_THRESHOLD_USD = 1.00
 
-# Per-run wall-clock budget for the --sync generate path (seconds). The blog-summary
-# autopilot runs under a 60-min GitHub Actions cap; --sync summarizes the whole blog
-# back-catalog one call at a time on the FIRST run (idempotency has nothing to skip
-# yet). Without a budget the job was SIGKILLed at 60 min BEFORE it could checkpoint
-# summary-state.json — so every run restarted from zero and it never once succeeded
-# (tracker-138 reopened). generate_sync stops starting new calls past this budget and
-# returns partial; the caller checkpoints what finished + the CI job commits it, so the
-# backlog drains across a few bounded runs, then daily runs are true no-ops. 40 min
-# leaves headroom for one in-flight call (≤ _GEMINI_CALL_HARD_TIMEOUT_SEC) plus the
-# commit/notify steps, under the 60-min cap.
+# ── Whole-run wall-clock budget (tracker-138, PERMANENT fix 2026-07-13) ───────────────────────────────
+# The blog-summary autopilot timed out at the 60-min GitHub Actions cap EVERY day for 6+ weeks and never
+# once succeeded. Root cause: the budget below (SYNC_RUN_DEADLINE_SEC) bounded ONLY a single generate_sync
+# CALL — but the pipeline calls generate_sync TWICE (main pass + a retry pass that got a FRESH 40-min
+# budget) and then ran an UNBOUNDED Webflow write-back. On the first-run/stale backlog (~142 posts) the
+# TOTAL rode past the 60-min cap, the job was SIGKILLed BEFORE _save_summary_state (which ran only at the
+# very end), so nothing checkpointed, the idempotency state stayed stale, and it re-did the whole backlog
+# and timed out again — forever. The fix is a SINGLE run-wide deadline shared by every phase (both
+# generate passes + the write-back loop) so the process returns partial and cleanly, plus a hard watchdog
+# backstop (below) and incremental per-item checkpointing so progress is never lost. Both sit under 60 min.
+GENERATE_DEADLINE_SEC = 2100     # 35 min: generation (both passes) stops STARTING new calls here and defers the
+                                 # rest. It MUST stop earlier than RUN_DEADLINE_SEC so a big first-run backlog
+                                 # cannot eat the whole budget and STARVE write-back — leaving items generated
+                                 # (and billed) but never written or checkpointed. The ~10-min gap to
+                                 # RUN_DEADLINE_SEC is reserved to WRITE what this run generated.
+RUN_DEADLINE_SEC = 2700          # 45 min: write-back stops STARTING new writes here; whatever was written is
+                                 # published + checkpointed, the rest defers to the next run. ~15 min of headroom
+                                 # under the 60-min cap for the publish/report/commit tail.
+RUN_WATCHDOG_HARD_SEC = 3120     # 52 min: defense-in-depth backstop — a daemon timer force-exits the process
+                                 # with status 0 (a CLEAN exit, not a SIGKILL) if ANYTHING hangs past this, so
+                                 # the incrementally-checkpointed state still commits and the backlog drains.
+
+# Legacy per-CALL generate_sync budget. SUPERSEDED by RUN_DEADLINE_SEC (which is shared across passes);
+# retained only as the fallback when the summary CLI runs without a computed run-deadline (e.g. a unit test
+# that calls _submit_and_wait directly). Do not use for new work — thread the shared run-deadline instead.
 SYNC_RUN_DEADLINE_SEC = 2400
 
 # Locales. EN is the source language; the other 8 are translation targets.

--- a/tools/summary/tests/test_cli.py
+++ b/tools/summary/tests/test_cli.py
@@ -1292,6 +1292,256 @@ def test_write_back_publishes_written_items_when_publish_flag_set(tmp_path, monk
     assert out["publish"]["collection_failures"] == 0
 
 
+def test_generate_english_blog_run_is_bounded_and_checkpoints_incrementally(tmp_path, monkeypatch):
+    """tracker-138 WIRING regression (the 6-week daily-timeout incident): drive the WHOLE live blog pipeline
+    end-to-end and prove (1) _execute_generate_english threads ONE shared run-deadline into generate_sync
+    (bounded, NOT the legacy 2400s per-call budget) and (2) it checkpoints summary-state.json INCREMENTALLY
+    as each item is written — so a run that ends early still drains the backlog. A green unit test of each
+    piece is necessary but not sufficient; this proves the pieces are actually wired together."""
+    import types as _types
+    from tools.summary import batch_runner, webflow_client, config, llms_parser
+    from tools.summary import qa as _qa
+
+    state_file = tmp_path / "summary-state.json"
+    monkeypatch.setattr(config, "SUMMARY_STATE_FILE", state_file)
+    monkeypatch.setattr(config, "WEGLOT_IMPORTS_DIR", tmp_path / "weglot-out")
+    monkeypatch.setattr(config, "GENERATE_DEADLINE_SEC", 200.0)     # generation budget (< run budget)
+    monkeypatch.setattr(config, "RUN_DEADLINE_SEC", 300.0)          # bounded, positive → a real shared deadline
+    monkeypatch.setattr(cli, "_start_run_watchdog", lambda *_a, **_k: None)  # isolate: no real timer in the test
+    monkeypatch.setattr(llms_parser, "fetch_and_parse", lambda *a, **kw: llms_parser.LlmsIndex(entries=[]))
+    monkeypatch.setattr(cli, "_execute_audit", lambda *a, **kw: {})
+    monkeypatch.setattr(cli, "_execute_translate", lambda *a, **kw: {})
+    # QA is not under test here — force pass so all three items reach write-back.
+    monkeypatch.setattr(_qa, "qa_checks", lambda *a, **kw: _types.SimpleNamespace(passed=True, score=95.0, notes=[]))
+    monkeypatch.setattr(_qa, "boilerplate_pairs", lambda *a, **kw: [])
+
+    blog_cid = config.COLLECTIONS["blog"]
+    items = [
+        webflow_client.CmsItem(
+            id=f"b{i}", collection_id=blog_cid,
+            field_data={"name": f"Post {i}", "slug": f"post-{i}", "post-body": "Some blog body text about studying."},
+            is_archived=False, is_draft=False,
+        )
+        for i in range(3)
+    ]
+    monkeypatch.setattr(webflow_client.WebflowClient, "_get_token", lambda self: "fake")
+    monkeypatch.setattr(webflow_client.WebflowClient, "list_items", lambda self, cid, **kw: iter(items))
+    monkeypatch.setattr(
+        webflow_client.WebflowClient, "update_item_summary",
+        lambda self, **kw: webflow_client.WriteResult(dry_run=False, success=True, method="PATCH", url="x"),
+    )
+    monkeypatch.setattr(
+        webflow_client.WebflowClient, "publish_items",
+        lambda self, collection_id, item_ids: webflow_client.WriteResult(
+            dry_run=False, success=True, method="POST", url="x",
+            response={"publishedItemIds": item_ids},
+        ),
+    )
+
+    captured_deadline: list = []
+
+    def fake_sync(requests, run_deadline_sec=None, **kw):
+        captured_deadline.append(run_deadline_sec)
+        return [batch_runner.BatchResult(custom_id=r.custom_id, succeeded=True,
+                                         content="## A blog question\n\nA clear answer paragraph.\n")
+                for r in requests]
+
+    monkeypatch.setattr(batch_runner, "generate_sync", fake_sync)
+
+    rc = cli.main([
+        "generate-english", "--collection", "blog", "--no-dry-run", "--sync",
+        "--confirm-cost", "--publish", "--out-dir", str(tmp_path / "run"),
+    ])
+
+    assert rc == 0
+    # (1) generate_sync got a BOUNDED, shared generation deadline — derived from GENERATE_DEADLINE_SEC (which
+    #     is reserved to fire EARLIER than the run deadline so write-back never starves), never the legacy
+    #     per-call 2400s. (This is the wiring the tracker-138 "fix" silently lacked.)
+    assert captured_deadline and captured_deadline[0] is not None
+    assert 0 < captured_deadline[0] <= 200.0, captured_deadline
+    assert captured_deadline[0] != config.SYNC_RUN_DEADLINE_SEC
+    # (2) state was checkpointed INCREMENTALLY through the real run — all three written items are persisted,
+    #     so a SIGKILL/watchdog exit after this point would still let the backlog drain next run.
+    assert state_file.exists(), "summary-state.json was never written — the backlog can never drain"
+    persisted = json.loads(state_file.read_text())
+    assert set(persisted) == {"b0", "b1", "b2"}, persisted
+    phase = json.loads((tmp_path / "run" / "report.json").read_text())["phases"]["generate_english"]
+    assert phase["write_log"]["cms_writes"] == 3
+    assert phase["write_log"]["deferred"] == 0
+
+
+def test_generate_english_retry_pass_is_also_bounded_by_the_shared_deadline(tmp_path, monkeypatch):
+    """tracker-138 ROOT-CAUSE regression: the failure that ran for 6 weeks was a RETRY pass that got a FRESH
+    budget. Drive a full run where the FIRST generate pass fails an item (triggering the retry at cli.py:919)
+    and assert the retry pass ALSO receives a bounded, shared generation deadline — not None, not the legacy
+    2400s, and no larger than the first pass. A green suite that never exercises the retry pass is exactly why
+    the original 'fix' silently didn't work."""
+    import types as _types
+    from tools.summary import batch_runner, webflow_client, config, llms_parser
+    from tools.summary import qa as _qa
+
+    monkeypatch.setattr(config, "SUMMARY_STATE_FILE", tmp_path / "summary-state.json")
+    monkeypatch.setattr(config, "WEGLOT_IMPORTS_DIR", tmp_path / "weglot-out")
+    monkeypatch.setattr(config, "GENERATE_DEADLINE_SEC", 200.0)
+    monkeypatch.setattr(config, "RUN_DEADLINE_SEC", 300.0)
+    monkeypatch.setattr(cli, "_start_run_watchdog", lambda *_a, **_k: None)
+    monkeypatch.setattr(llms_parser, "fetch_and_parse", lambda *a, **kw: llms_parser.LlmsIndex(entries=[]))
+    monkeypatch.setattr(cli, "_execute_audit", lambda *a, **kw: {})
+    monkeypatch.setattr(cli, "_execute_translate", lambda *a, **kw: {})
+    monkeypatch.setattr(_qa, "qa_checks", lambda *a, **kw: _types.SimpleNamespace(passed=True, score=95.0, notes=[]))
+    monkeypatch.setattr(_qa, "boilerplate_pairs", lambda *a, **kw: [])
+
+    blog_cid = config.COLLECTIONS["blog"]
+    items = [webflow_client.CmsItem(
+        id="b0", collection_id=blog_cid,
+        field_data={"name": "Post 0", "slug": "post-0", "post-body": "Some blog body text about studying."},
+        is_archived=False, is_draft=False)]
+    monkeypatch.setattr(webflow_client.WebflowClient, "_get_token", lambda self: "fake")
+    monkeypatch.setattr(webflow_client.WebflowClient, "list_items", lambda self, cid, **kw: iter(items))
+    monkeypatch.setattr(
+        webflow_client.WebflowClient, "update_item_summary",
+        lambda self, **kw: webflow_client.WriteResult(dry_run=False, success=True, method="PATCH", url="x"))
+    monkeypatch.setattr(
+        webflow_client.WebflowClient, "publish_items",
+        lambda self, collection_id, item_ids: webflow_client.WriteResult(
+            dry_run=False, success=True, method="POST", url="x", response={"publishedItemIds": item_ids}))
+
+    calls: list = []
+
+    def fake_sync(requests, run_deadline_sec=None, **kw):
+        calls.append(run_deadline_sec)
+        succeeded = len(calls) > 1                      # first pass FAILS the item → forces the retry pass
+        return [batch_runner.BatchResult(
+            custom_id=r.custom_id, succeeded=succeeded,
+            content=("## A blog question\n\nA clear answer.\n" if succeeded else ""),
+            error=(None if succeeded else "transient boom")) for r in requests]
+
+    monkeypatch.setattr(batch_runner, "generate_sync", fake_sync)
+
+    rc = cli.main([
+        "generate-english", "--collection", "blog", "--no-dry-run", "--sync",
+        "--confirm-cost", "--publish", "--out-dir", str(tmp_path / "run"),
+    ])
+
+    assert rc == 0
+    assert len(calls) == 2, f"retry pass did not run (calls={calls})"
+    assert calls[0] is not None and calls[1] is not None
+    # The RETRY pass got a bounded, shared generation budget — never None, never the legacy 2400s per-call
+    # budget, and no larger than the first pass (they share one shrinking deadline).
+    assert 0 < calls[1] <= 200.0, calls
+    assert calls[1] != config.SYNC_RUN_DEADLINE_SEC
+    assert calls[1] <= calls[0]
+
+
+def test_submit_and_wait_shares_one_run_deadline_across_passes(monkeypatch):
+    """tracker-138 ROOT CAUSE: the retry pass used to get a FRESH per-call budget, so the main pass AND
+    the retry pass could each run ~40 min and ride the run past the 60-min GitHub Actions cap (SIGKILL
+    before any checkpoint → the blog autopilot timed out every day for 6+ weeks). Both passes must now be
+    bounded by the REMAINING budget to ONE shared absolute deadline, so the retry gets only what's left."""
+    import argparse
+    from tools.summary import batch_runner
+
+    captured: list = []
+
+    def fake_gs(requests, run_deadline_sec=None, **kw):
+        captured.append(run_deadline_sec)
+        return [batch_runner.BatchResult(custom_id=r.custom_id, succeeded=True, content="x") for r in requests]
+
+    monkeypatch.setattr(batch_runner, "generate_sync", fake_gs)
+    clock = [1000.0]
+    monkeypatch.setattr(cli.time, "monotonic", lambda: clock[0])
+
+    args = argparse.Namespace(sync=True)
+    reqs = [batch_runner.BatchRequest(custom_id="a", system_blocks=[], user_message="m")]
+    deadline = clock[0] + 100.0                                # 100s whole-run budget
+    cli._submit_and_wait(reqs, args, run_deadline=deadline)     # main pass → remaining 100
+    clock[0] += 30.0                                            # 30s elapses before the retry
+    cli._submit_and_wait(reqs, args, run_deadline=deadline)     # retry pass → remaining 70
+
+    assert captured == [100.0, 70.0]
+    assert captured[1] < captured[0], "retry must share the run budget, not get a fresh one"
+
+
+def test_write_back_stops_at_run_deadline_and_checkpoints_each_write(tmp_path, monkeypatch):
+    """tracker-138: write-back must (a) STOP starting new writes past the shared run deadline (returning the
+    rest as `deferred`, so the run stays under the cap) and (b) fire on_written per SUCCESSFUL write so the
+    caller checkpoints idempotency state incrementally — the two properties that make a partial run DRAIN
+    instead of losing everything when the process ends early."""
+    from tools.summary import batch_runner, webflow_client, config
+    from tools.summary.prompt_builder import KeywordPlan, SourceItem
+
+    monkeypatch.setattr(config, "WEGLOT_IMPORTS_DIR", tmp_path / "weglot-out")
+    monkeypatch.setattr(webflow_client.WebflowClient, "_get_token", lambda self: "fake")
+    monkeypatch.setattr(
+        webflow_client.WebflowClient, "update_item_summary",
+        lambda self, **kw: webflow_client.WriteResult(dry_run=False, success=True, method="PATCH", url="x"),
+    )
+    sources = [
+        (SourceItem(url=f"https://www.englishcollege.com/post/{i}", title="B", body_excerpt="b",
+                    locale="en", content_type="blog_post", cms_item_id=f"b{i}"), KeywordPlan(primary="x"), "cms")
+        for i in range(3)
+    ]
+    results = [
+        batch_runner.BatchResult(custom_id=f"gen-{i}-b{i}", succeeded=True, content="## Q\n\nAn answer.\n")
+        for i in range(3)
+    ]
+
+    class _Args:
+        dry_run = False
+
+    clock = [5000.0]
+    monkeypatch.setattr(cli.time, "monotonic", lambda: clock[0])
+
+    # (a) deadline already in the past → nothing written, ALL deferred.
+    written: list = []
+    log = cli._write_back_summaries(
+        results, sources, _Args(), tmp_path, [],
+        run_deadline=clock[0] - 1.0, on_written=lambda it: written.append(it.cms_item_id),
+    )
+    assert log["cms_writes"] == 0 and log["deferred"] == 3 and written == []
+
+    # (b) generous deadline → all written AND on_written fires exactly once per item, in order.
+    written.clear()
+    log2 = cli._write_back_summaries(
+        results, sources, _Args(), tmp_path, [],
+        run_deadline=clock[0] + 10_000.0, on_written=lambda it: written.append(it.cms_item_id),
+    )
+    assert log2["cms_writes"] == 3 and log2["deferred"] == 0
+    assert written == ["b0", "b1", "b2"]
+
+
+def test_run_watchdog_force_exits_nonzero_to_alert(monkeypatch):
+    """tracker-138 backstop: the normal bounded run stops COOPERATIVELY at the generate/run deadlines and
+    exits 0 on its own, so the watchdog only ever fires on a genuine HANG the cooperative stops did not
+    catch. That is abnormal, so it must exit NON-ZERO — that is what makes the workflow's 'Notify on failure'
+    step fire (an earlier cut exited 0 and re-created the exact silent-hang the alert exists to prevent).
+    Durability is independent of the exit code (incremental checkpoint + always()-commit), so exiting
+    non-zero drains AND alerts. Verifies it fires with a non-zero code (os._exit is stubbed so the test
+    process survives)."""
+    import threading as _threading
+
+    fired = _threading.Event()
+    codes: list = []
+    monkeypatch.setattr(cli.os, "_exit", lambda code: (codes.append(code), fired.set()) and None)
+
+    timer = cli._start_run_watchdog(0.05)
+    assert timer.daemon is True, "watchdog must be a daemon so it never blocks a normal exit"
+    assert fired.wait(2.0), "watchdog did not fire within its hard budget"
+    assert codes == [cli._WATCHDOG_EXIT_CODE], codes
+    assert cli._WATCHDOG_EXIT_CODE != 0, "watchdog must exit NON-ZERO so the failure alert fires"
+
+
+def test_run_deadline_ordering_reserves_writeback_and_stays_under_the_job_cap():
+    """tracker-138 STARVATION + cap guard: generation must stop before write-back's deadline (else a big
+    backlog eats the whole budget and starves write-back → nothing written or checkpointed → never drains),
+    write-back must stop before the hard watchdog, and the watchdog must fire before the 60-min GitHub
+    Actions job cap SIGKILLs the process. This ordering is the whole fix; lock it so it can't silently drift."""
+    from tools.summary import config
+    assert config.GENERATE_DEADLINE_SEC < config.RUN_DEADLINE_SEC, "generation must reserve write-back headroom"
+    assert config.RUN_DEADLINE_SEC < config.RUN_WATCHDOG_HARD_SEC, "write-back must finish before the hard backstop"
+    assert config.RUN_WATCHDOG_HARD_SEC < 60 * 60, "the watchdog must exit cleanly BEFORE the 60-min job cap"
+
+
 def test_generate_english_sync_uses_generate_sync_not_batch(tmp_path, monkeypatch):
     """tracker-096 review: --sync routes generation through batch_runner.generate_sync
     (instant) and must NOT touch the Batch API (submit_batch / wait_for_batch)."""


### PR DESCRIPTION
## The bug
The **Blog summary autopilot** ([run 29229563534](https://github.com/cagdasunal/CEL/actions/runs/29229563534)) has **timed out (cancelled) at the 60-min job cap every single day for 6+ weeks and never once succeeded** (issue #55). Step 5 "Generate + publish blog summaries" ran the full hour and was SIGKILLed.

## Root cause
The per-run budget `SYNC_RUN_DEADLINE_SEC` (40 min) bounded only **one** `generate_sync` *call*. But the pipeline (`_execute_generate_english`):
1. calls `generate_sync` **twice** — a main pass **and a retry pass that got a fresh 40-min budget**, and
2. then runs an **unbounded** Webflow write-back, and
3. saves `summary-state.json` **only at the very end**.

So on the first-run/stale backlog (~142 posts) the total rode past 60 min → the job was **SIGKILLed before the checkpoint** → nothing persisted → the idempotency state stayed stale → it re-did the whole backlog and timed out again, forever. The prior "fix" (tracker-138) had **no test**, which is why it silently didn't work.

## The fix (defense in depth)
| Layer | What |
|---|---|
| **Shared generation deadline** | Both generate passes (main + retry) share ONE budget (`GENERATE_DEADLINE_SEC`, 35 min) — the retry no longer gets a fresh one. It fires **earlier** than write-back's deadline so a big backlog can't starve write-back. |
| **Bounded, incremental write-back** | Write-back stops past `RUN_DEADLINE_SEC` (45 min) and checkpoints each item **atomically as it's written** (and only items that actually wrote — fixes a latent bug that marked failed writes "done"). A partial run always drains. |
| **Hard watchdog** | `RUN_WATCHDOG_HARD_SEC` (52 min) force-exits if anything hangs, **non-zero** so the "Notify on failure" alert still fires. Scoped to `--sync` so long-running Batch runs are never killed. |
| **Commit on cancel** | The commit step now runs on `always()` so a partial checkpoint commits even if the job is still somehow cancelled. |

All under the 60-min cap: generate 35 → write-back 45 → watchdog 52 → cap 60.

## Verified + tested
- 6 new tests, all **mutation-checked**, including the **retry-pass wiring** (the exact untested path that caused this) and a full end-to-end wiring test. Full summary+core suite green (320+ tests).
- Hardened after an **adversarial multi-agent review** — the watchdog's non-zero exit (alert preservation), `--sync` scoping (don't kill Batch runs), and the retry-pass test all came from confirmed findings.

After merge, the next scheduled run (or a manual `workflow_dispatch`) should finish under 60 min and drain the backlog over a few runs, then steady-state no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)